### PR TITLE
Fixed HkGetClientID

### DIFF
--- a/source/HkFuncTools.cpp
+++ b/source/HkFuncTools.cpp
@@ -12,7 +12,11 @@ HK_ERROR HkGetClientID(bool& bIdString, uint& iClientID, const std::wstring &wsc
 			if((hkErr == HKE_AMBIGUOUS_SHORTCUT) || (hkErr == HKE_NO_MATCHING_PLAYER))
 				return hkErr;
 			if(hkErr == HKE_INVALID_SHORTCUT_STRING)
+			{
 				iClientID = HkGetClientIdFromCharname(wscCharname);
+				if (iClientID != INT_MAX)
+					return HKE_OK;
+			}
 		}
 	}
 	return hkErr;

--- a/source/HkFuncTools.cpp
+++ b/source/HkFuncTools.cpp
@@ -14,8 +14,10 @@ HK_ERROR HkGetClientID(bool& bIdString, uint& iClientID, const std::wstring &wsc
 			if(hkErr == HKE_INVALID_SHORTCUT_STRING)
 			{
 				iClientID = HkGetClientIdFromCharname(wscCharname);
-				if (iClientID != INT_MAX)
+				if (iClientID != (uint)-1)
 					return HKE_OK;
+				else
+					return HKE_PLAYER_NOT_LOGGED_IN;
 			}
 		}
 	}


### PR DESCRIPTION
Will return HKE_OK if it can find a logged in player with HkGetClientIdFromCharname. Otherwise return HKE_PLAYER_NOT_LOGGED_IN