### PR TITLE
* Do not use WriteProcMem in HkIClientImpl::CDPClientProxy__GetLinkSa…

### DIFF
--- a/source/HkCbIClientImpl.cpp
+++ b/source/HkCbIClientImpl.cpp
@@ -41,10 +41,10 @@ double HkIClientImpl::CDPClientProxy__GetLinkSaturation(uint iClientID)
 	// ISERVER_LOGARG_UI(iClientID);
 
 	char *tmp; 
-	WriteProcMem(&tmp, &Client, 4); 
-	WriteProcMem(&Client, &OldClient, 4); 
+	memcpy(&tmp, &Client, 4);
+	memcpy(&Client, &OldClient, 4);
 	double dRet = HookClient->CDPClientProxy__GetLinkSaturation(iClientID); 
-	WriteProcMem(&Client, &tmp, 4); 
+	memcpy(&Client, &tmp, 4);
 
 	return dRet;
 }


### PR DESCRIPTION
…turation

- Using it in this function wastes an insane amount of cpu cycles and causes high server load with e.g. a lot of loot in space
- Should be fine to use memcpy here, since the variable already has been written to with WriteProcMem on startup
- Tested successfully on Windows 7