### PR TITLE
Mark Plugin 

### DIFF
--- a/plugins/mark_plugin/Main.cpp
+++ b/plugins/mark_plugin/Main.cpp
@@ -47,13 +47,13 @@ void UserCmd_MarkObj(uint iClientID, const std::wstring& wscParam)
 		//PRINT_OK()
 		break;
 	case 1:
-		PrintUserCmdText(iClientID, L"Error: you must have something targeted to mark it.");
+		PrintUserCmdText(iClientID, L"Error: You must have something targeted to mark it.");
 		break;
 	case 2:
-		PrintUserCmdText(iClientID, L"Error: you cannot mark cloaked ships.");
+		PrintUserCmdText(iClientID, L"Error: You cannot mark cloaked ships.");
 		break;
 	case 3:
-		PrintUserCmdText(iClientID, L"Error: object is already marked.");
+		PrintUserCmdText(iClientID, L"Error: Object is already marked.");
 	default:
 		break;
 	}
@@ -71,10 +71,10 @@ void UserCmd_UnMarkObj(uint iClientID, const std::wstring& wscParam)
 		//PRINT_OK()
 		break;
 	case 1:
-		PrintUserCmdText(iClientID, L"Error: you must have something targeted to unmark it.");
+		PrintUserCmdText(iClientID, L"Error: You must have something targeted to unmark it.");
 		break;
 	case 2:
-		PrintUserCmdText(iClientID, L"Error: object is not marked.");
+		PrintUserCmdText(iClientID, L"Error: Object is not marked.");
 	default:
 		break;
 	}
@@ -93,7 +93,7 @@ void UserCmd_MarkObjGroup(uint iClientID, const std::wstring& wscParam)
 	pub::SpaceObj::GetTarget(iShip, iTargetShip);
 	if (!iTargetShip)
 	{
-		PrintUserCmdText(iClientID, L"Error: you must have something targeted to mark it.");
+		PrintUserCmdText(iClientID, L"Error: You must have something targeted to mark it.");
 		return;
 	}
 	std::list<GROUP_MEMBER> lstMembers;
@@ -119,7 +119,7 @@ void UserCmd_UnMarkObjGroup(uint iClientID, const std::wstring& wscParam)
 	pub::SpaceObj::GetTarget(iShip, iTargetShip);
 	if (!iTargetShip)
 	{
-		PrintUserCmdText(iClientID, L"Error: you must have something targeted to mark it.");
+		PrintUserCmdText(iClientID, L"Error: You must have something targeted to mark it.");
 		return;
 	}
 	std::list<GROUP_MEMBER> lstMembers;
@@ -681,12 +681,18 @@ EXPORT void LoadUserCharSettings(uint iClientID)
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 EXPORT void UserCmd_Help(uint iClientID, const std::wstring& wscParam)
 {
-	PrintUserCmdText(iClientID, L"/mark /m <--- Makes the selected object appear in the important section of the contacts and\n  have an arrow on the side of the screen, as well as have > and < on the sides\n  of the selection box.");
-	PrintUserCmdText(iClientID, L"/unmark /um <--- Unmarks the selected object marked with the /mark (/m) command.");
-	PrintUserCmdText(iClientID, L"/groupmark /gm <--- Marks selected object for the entire group.");
-	PrintUserCmdText(iClientID, L"/groupunmark /gum <--- Unmarks the selected object for the entire group.");
-	PrintUserCmdText(iClientID, L"/ignoregroupmarks <on|off> <--- Ignores marks from others in your group.");
-	PrintUserCmdText(iClientID, L"/automark <on|off> [radius in KM] <--- Automatically marks all ships in KM radius.  Bots are marked automatically in the\n  range specified whether on or off.  If you want to completely disable automarking,\n  set the radius to a number <= 0.");
+	PrintUserCmdText(iClientID, L"/mark /m ");
+	PrintUserCmdText(iClientID, L"Makes the selected object appear in the important section of the contacts and have an arrow on the side of the screen, as well as have > and < on the sides of the selection box.");
+	PrintUserCmdText(iClientID, L"/unmark /um");
+	PrintUserCmdText(iClientID, L"Unmarks the selected object marked with the /mark (/m) command.");
+	PrintUserCmdText(iClientID, L"/groupmark /gm");
+	PrintUserCmdText(iClientID, L"Marks selected object for the entire group.");
+	PrintUserCmdText(iClientID, L"/groupunmark /gum");
+	PrintUserCmdText(iClientID, L"Unmarks the selected object for the entire group.");
+	PrintUserCmdText(iClientID, L"/ignoregroupmarks <on|off>");
+	PrintUserCmdText(iClientID, L"Ignores marks from others in your group.");
+	PrintUserCmdText(iClientID, L"/automark <on|off> [radius in KM]");
+	PrintUserCmdText(iClientID, L"Automatically marks all ships in KM radius.Bots are marked automatically in the\n  range specified whether on or off. If you want to completely disable automarking, set the radius to a number <= 0.");
 }
 
 USERCMD UserCmds[] =

--- a/plugins/mark_plugin/Main.cpp
+++ b/plugins/mark_plugin/Main.cpp
@@ -1,8 +1,7 @@
-// This is a template with the bare minimum to have a functional plugin.
-//
-// This is free software; you can redistribute it and/or modify it as
-// you wish without restriction. If you do then I would appreciate
-// being notified and/or mentioned somewhere.
+// Mark Plugin
+// Originally by M0tah
+// https://sourceforge.net/projects/kosacid/files/
+
 
 #include "Main.h" 
 

--- a/plugins/mark_plugin/Main.cpp
+++ b/plugins/mark_plugin/Main.cpp
@@ -2,7 +2,6 @@
 // Originally by M0tah
 // https://sourceforge.net/projects/kosacid/files/
 
-
 #include "Main.h" 
 
 #define PRINT_DISABLED() PrintUserCmdText(iClientID, L"Command disabled");
@@ -20,7 +19,7 @@ EXPORT void LoadSettings()
 
 	char szCurDir[MAX_PATH];
 	GetCurrentDirectory(sizeof(szCurDir), szCurDir);
-	scMarkFile = std::string(szCurDir) + "\\flhook_plugins\\mark.ini";
+	scMarkFile = std::string(szCurDir) + "\\flhook_plugins\\mark.cfg";
 	set_fAutoMarkRadius = IniGetF(scMarkFile, "General", "AutoMarkRadius", 2.0f) * 1000;
 }
 EXPORT PLUGIN_RETURNCODE Get_PluginReturnCode()
@@ -662,6 +661,12 @@ namespace HkIServerImpl
 		}
 		return 0;
 	}
+
+	EXPORT void __stdcall DisConnect(unsigned int iClientID, enum EFLConnection p2)
+	{
+		returncode = DEFAULT_RETURNCODE;
+		ClearClientMark(iClientID);
+	}
 }
 
 EXPORT void LoadUserCharSettings(uint iClientID)
@@ -748,6 +753,7 @@ EXPORT PLUGIN_INFO* Get_PluginInfo()
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&HkIServerImpl::LaunchComplete, PLUGIN_HkIServerImpl_LaunchComplete, 0));
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&HkIServerImpl::BaseEnter, PLUGIN_HkIServerImpl_BaseEnter, 0));
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&HkIServerImpl::Update, PLUGIN_HkIServerImpl_Update, 0));
+	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&HkIServerImpl::DisConnect, PLUGIN_HkIServerImpl_DisConnect, 0));
 	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&LoadUserCharSettings, PLUGIN_LoadUserCharSettings, 0));
 	return p_PI;
 }

--- a/plugins/mark_plugin/Main.cpp
+++ b/plugins/mark_plugin/Main.cpp
@@ -1,0 +1,748 @@
+// This is a template with the bare minimum to have a functional plugin.
+//
+// This is free software; you can redistribute it and/or modify it as
+// you wish without restriction. If you do then I would appreciate
+// being notified and/or mentioned somewhere.
+
+#include "Main.h" 
+
+#define PRINT_DISABLED() PrintUserCmdText(iClientID, L"Command disabled");
+#define PRINT_ERROR() { for(uint i = 0; (i < sizeof(wscError)/sizeof(std::wstring)); i++) PrintUserCmdText(iClientID, wscError[i]); return; }
+
+MARK_INFO Mark[250];
+float set_fAutoMarkRadius;
+std::vector<uint> vMarkSpaceObjProc;
+bool set_bFlakVersion = true;
+std::string scMarkFile;
+
+EXPORT void LoadSettings()
+{
+	returncode = DEFAULT_RETURNCODE;
+
+	char szCurDir[MAX_PATH];
+	GetCurrentDirectory(sizeof(szCurDir), szCurDir);
+	scMarkFile = std::string(szCurDir) + "\\flhook_plugins\\mark.ini";
+	set_fAutoMarkRadius = IniGetF(scMarkFile, "General", "AutoMarkRadius", 2.0f) * 1000;
+}
+EXPORT PLUGIN_RETURNCODE Get_PluginReturnCode()
+{
+	return returncode;
+}
+
+BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
+{
+	if (fdwReason == DLL_PROCESS_ATTACH)
+		LoadSettings();
+	return true;
+}
+
+void UserCmd_MarkObj(uint iClientID, const std::wstring& wscParam)
+{
+	uint iShip, iTargetShip;
+	pub::Player::GetShip(iClientID, iShip);
+	pub::SpaceObj::GetTarget(iShip, iTargetShip);
+	char err = HkMarkObject(iClientID, iTargetShip);
+	switch (err)
+	{
+	case 0:
+		//PRINT_OK()
+		break;
+	case 1:
+		PrintUserCmdText(iClientID, L"Error: you must have something targeted to mark it.");
+		break;
+	case 2:
+		PrintUserCmdText(iClientID, L"Error: you cannot mark cloaked ships.");
+		break;
+	case 3:
+		PrintUserCmdText(iClientID, L"Error: object is already marked.");
+	default:
+		break;
+	}
+}
+
+void UserCmd_UnMarkObj(uint iClientID, const std::wstring& wscParam)
+{
+	uint iShip, iTargetShip;
+	pub::Player::GetShip(iClientID, iShip);
+	pub::SpaceObj::GetTarget(iShip, iTargetShip);
+	char err = HkUnMarkObject(iClientID, iTargetShip);
+	switch (err)
+	{
+	case 0:
+		//PRINT_OK()
+		break;
+	case 1:
+		PrintUserCmdText(iClientID, L"Error: you must have something targeted to unmark it.");
+		break;
+	case 2:
+		PrintUserCmdText(iClientID, L"Error: object is not marked.");
+	default:
+		break;
+	}
+}
+
+void UserCmd_UnMarkAllObj(uint iClientID, const std::wstring& wscParam)
+{
+	HkUnMarkAllObjects(iClientID);
+	//PRINT_OK()
+}
+
+void UserCmd_MarkObjGroup(uint iClientID, const std::wstring& wscParam)
+{
+	uint iShip, iTargetShip;
+	pub::Player::GetShip(iClientID, iShip);
+	pub::SpaceObj::GetTarget(iShip, iTargetShip);
+	if (!iTargetShip)
+	{
+		PrintUserCmdText(iClientID, L"Error: you must have something targeted to mark it.");
+		return;
+	}
+	std::list<GROUP_MEMBER> lstMembers;
+	lstMembers.clear();
+	std::wstring wsClientID = (wchar_t*)Players.GetActiveCharacterName(iClientID);
+	HkGetGroupMembers(wsClientID, lstMembers);
+	for (auto& lstG : lstMembers)
+	{
+		if (Mark[lstG.iClientID].bIgnoreGroupMark)
+			continue;
+		uint iClientShip;
+		pub::Player::GetShip(lstG.iClientID, iClientShip);
+		if (iClientShip == iTargetShip)
+			continue;
+		HkMarkObject(lstG.iClientID, iTargetShip);
+	}
+}
+
+void UserCmd_UnMarkObjGroup(uint iClientID, const std::wstring& wscParam)
+{
+	uint iShip, iTargetShip;
+	pub::Player::GetShip(iClientID, iShip);
+	pub::SpaceObj::GetTarget(iShip, iTargetShip);
+	if (!iTargetShip)
+	{
+		PrintUserCmdText(iClientID, L"Error: you must have something targeted to mark it.");
+		return;
+	}
+	std::list<GROUP_MEMBER> lstMembers;
+	lstMembers.clear();
+	std::wstring wsClientID = (wchar_t*)Players.GetActiveCharacterName(iClientID);
+	HkGetGroupMembers(wsClientID, lstMembers);
+	for (auto& lstG : lstMembers)
+	{
+		HkUnMarkObject(lstG.iClientID, iTargetShip);
+	}
+}
+
+void UserCmd_SetIgnoreGroupMark(uint iClientID, const std::wstring& wscParam)
+{
+	std::wstring wscError[] =
+	{
+		L"Error: Invalid parameters",
+		L"Usage: /ignoregroupmarks <on|off>",
+	};
+
+	if (ToLower(wscParam) == L"off")
+	{
+		Mark[iClientID].bIgnoreGroupMark = false;
+		std::wstring wscDir, wscFilename;
+		CAccount* acc = Players.FindAccountFromClientID(iClientID);
+		if (HKHKSUCCESS(HkGetCharFileName(ARG_CLIENTID(iClientID), wscFilename)) && HKHKSUCCESS(HkGetAccountDirName(acc, wscDir)))
+		{
+			std::string scUserFile = scAcctPath + wstos(wscDir) + "\\flhookuser.ini";
+			std::string scSection = "general_" + wstos(wscFilename);
+			IniWrite(scUserFile, scSection, "automarkenabled", "no");
+			PrintUserCmdText(iClientID, L"Accepting marks from the group");
+		}
+	}
+	else if (ToLower(wscParam) == L"on")
+	{
+		Mark[iClientID].bIgnoreGroupMark = true;
+		std::wstring wscDir, wscFilename;
+		CAccount* acc = Players.FindAccountFromClientID(iClientID);
+		if (HKHKSUCCESS(HkGetCharFileName(ARG_CLIENTID(iClientID), wscFilename)) && HKHKSUCCESS(HkGetAccountDirName(acc, wscDir)))
+		{
+			std::string scUserFile = scAcctPath + wstos(wscDir) + "\\flhookuser.ini";
+			std::string scSection = "general_" + wstos(wscFilename);
+			IniWrite(scUserFile, scSection, "automarkenabled", "yes");
+			PrintUserCmdText(iClientID, L"Ignoring marks from the group");
+		}
+	}
+	else
+	{
+		PRINT_ERROR();
+	}
+}
+
+void UserCmd_AutoMark(uint iClientID, const std::wstring& wscParam)
+{
+	if (set_fAutoMarkRadius <= 0.0f) //automarking disabled
+	{
+		PRINT_DISABLED();
+		return;
+	}
+
+	std::wstring wscError[] =
+	{
+		L"Error: Invalid parameters",
+		L"Usage: /automark <on|off> [radius in KM]",
+	};
+
+	std::wstring wscEnabled = ToLower(GetParam(wscParam, ' ', 0));
+
+	if (!wscParam.length() || (wscEnabled != L"on" && wscEnabled != L"off"))
+	{
+		PRINT_ERROR();
+		return;
+	}
+
+	std::wstring wscRadius = GetParam(wscParam, ' ', 1);
+	float fRadius = 0.0f;
+	if (wscRadius.length())
+	{
+		fRadius = ToFloat(wscRadius);
+	}
+
+	//I think this section could be done better, but I can't think of it now..
+	if (!Mark[iClientID].bMarkEverything)
+	{
+		if (wscRadius.length())
+			Mark[iClientID].fAutoMarkRadius = fRadius * 1000;
+		if (wscEnabled == L"on") //AutoMark is being enabled
+		{
+			Mark[iClientID].bMarkEverything = true;
+			CAccount* acc = Players.FindAccountFromClientID(iClientID);
+			std::wstring wscDir, wscFilename;
+			if (HKHKSUCCESS(HkGetCharFileName(ARG_CLIENTID(iClientID), wscFilename)) && HKHKSUCCESS(HkGetAccountDirName(acc, wscDir)))
+			{
+				std::string scUserFile = scAcctPath + wstos(wscDir) + "\\flhookuser.ini";
+				std::string scSection = "general_" + wstos(wscFilename);
+				IniWrite(scUserFile, scSection, "automark", "yes");
+				if (wscRadius.length())
+					IniWrite(scUserFile, scSection, "automarkradius", ftos(Mark[iClientID].fAutoMarkRadius));
+			}
+			PrintUserCmdText(iClientID, L"Automarking turned on within a %g KM radius", Mark[iClientID].fAutoMarkRadius / 1000);
+		}
+		else if (wscRadius.length())
+		{
+			CAccount* acc = Players.FindAccountFromClientID(iClientID);
+			std::wstring wscDir, wscFilename;
+			if (HKHKSUCCESS(HkGetCharFileName(ARG_CLIENTID(iClientID), wscFilename)) && HKHKSUCCESS(HkGetAccountDirName(acc, wscDir)))
+			{
+				std::string scUserFile = scAcctPath + wstos(wscDir) + "\\flhookuser.ini";
+				std::string scSection = "general_" + wstos(wscFilename);
+				IniWrite(scUserFile, scSection, "automarkradius", ftos(Mark[iClientID].fAutoMarkRadius));
+			}
+			PrintUserCmdText(iClientID, L"Radius changed to %g KMs", fRadius);
+		}
+	}
+	else
+	{
+		if (wscRadius.length())
+			Mark[iClientID].fAutoMarkRadius = fRadius * 1000;
+		if (wscEnabled == L"off") //AutoMark is being disabled
+		{
+			Mark[iClientID].bMarkEverything = false;
+			CAccount* acc = Players.FindAccountFromClientID(iClientID);
+			std::wstring wscDir, wscFilename;
+			if (HKHKSUCCESS(HkGetCharFileName(ARG_CLIENTID(iClientID), wscFilename)) && HKHKSUCCESS(HkGetAccountDirName(acc, wscDir)))
+			{
+				std::string scUserFile = scAcctPath + wstos(wscDir) + "\\flhookuser.ini";
+				std::string scSection = "general_" + wstos(wscFilename);
+				IniWrite(scUserFile, scSection, "automark", "no");
+				if (wscRadius.length())
+					IniWrite(scUserFile, scSection, "automarkradius", ftos(Mark[iClientID].fAutoMarkRadius));
+			}
+			if (wscRadius.length())
+				PrintUserCmdText(iClientID, L"Automarking turned off; radius changed to %g KMs", Mark[iClientID].fAutoMarkRadius / 1000);
+			else
+				PrintUserCmdText(iClientID, L"Automarking turned off");
+		}
+		else if (wscRadius.length())
+		{
+			CAccount* acc = Players.FindAccountFromClientID(iClientID);
+			std::wstring wscDir, wscFilename;
+			if (HKHKSUCCESS(HkGetCharFileName(ARG_CLIENTID(iClientID), wscFilename)) && HKHKSUCCESS(HkGetAccountDirName(acc, wscDir)))
+			{
+				std::string scUserFile = scAcctPath + wstos(wscDir) + "\\flhookuser.ini";
+				std::string scSection = "general_" + wstos(wscFilename);
+				IniWrite(scUserFile, scSection, "automarkradius", ftos(Mark[iClientID].fAutoMarkRadius));
+			}
+			PrintUserCmdText(iClientID, L"Radius changed to %g KMs", fRadius);
+		}
+	}
+}
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+char HkMarkObject(uint iClientID, uint iObject)
+{
+	if (!iObject)
+		return 1;
+
+	uint iClientIDMark = HkGetClientIDByShip(iObject);
+
+	uint iSystemID, iObjectSystemID;
+	pub::Player::GetSystem(iClientID, iSystemID);
+	pub::SpaceObj::GetSystem(iObject, iObjectSystemID);
+	if (iSystemID == iObjectSystemID)
+	{
+		for (uint i = 0; i < Mark[iClientID].vMarkedObjs.size(); i++)
+		{
+			if (Mark[iClientID].vMarkedObjs[i] == iObject)
+				return 3; //already marked
+		}
+	}
+	else
+	{
+		for (uint j = 0; j < Mark[iClientID].vDelayedSystemMarkedObjs.size(); j++)
+		{
+			if (Mark[iClientID].vDelayedSystemMarkedObjs[j] == iObject)
+				return 3; //already marked
+		}
+		Mark[iClientID].vDelayedSystemMarkedObjs.push_back(iObject);
+		pub::Audio::PlaySoundEffect(iClientID, 2460046221); //CreateID("ui_select_add")
+		return 0;
+	}
+
+	pub::Player::MarkObj(iClientID, iObject, 1);
+	for (uint i = 0; i < Mark[iClientID].vAutoMarkedObjs.size(); i++) //remove from automarked vector
+	{
+		if (Mark[iClientID].vAutoMarkedObjs[i] == iObject)
+		{
+			if (i != Mark[iClientID].vAutoMarkedObjs.size() - 1)
+			{
+				Mark[iClientID].vAutoMarkedObjs[i] = Mark[iClientID].vAutoMarkedObjs[Mark[iClientID].vAutoMarkedObjs.size() - 1];
+			}
+			Mark[iClientID].vAutoMarkedObjs.pop_back();
+			break;
+		}
+	}
+	Mark[iClientID].vMarkedObjs.push_back(iObject);
+	pub::Audio::PlaySoundEffect(iClientID, 2460046221); //CreateID("ui_select_add")
+	return 0;
+}
+
+char HkUnMarkObject(uint iClientID, uint iObject)
+{
+	if (!iObject)
+		return 1;
+
+	for (uint i = 0; i < Mark[iClientID].vMarkedObjs.size(); i++)
+	{
+		if (Mark[iClientID].vMarkedObjs[i] == iObject)
+		{
+			if (i != Mark[iClientID].vMarkedObjs.size() - 1)
+			{
+				Mark[iClientID].vMarkedObjs[i] = Mark[iClientID].vMarkedObjs[Mark[iClientID].vMarkedObjs.size() - 1];
+			}
+			Mark[iClientID].vMarkedObjs.pop_back();
+			pub::Player::MarkObj(iClientID, iObject, 0);
+			pub::Audio::PlaySoundEffect(iClientID, 2939827141); //CreateID("ui_select_remove")
+			return 0;
+		}
+	}
+
+	for (uint j = 0; j < Mark[iClientID].vAutoMarkedObjs.size(); j++)
+	{
+		if (Mark[iClientID].vAutoMarkedObjs[j] == iObject)
+		{
+			if (j != Mark[iClientID].vAutoMarkedObjs.size() - 1)
+			{
+				Mark[iClientID].vAutoMarkedObjs[j] = Mark[iClientID].vAutoMarkedObjs[Mark[iClientID].vAutoMarkedObjs.size() - 1];
+			}
+			Mark[iClientID].vAutoMarkedObjs.pop_back();
+			pub::Player::MarkObj(iClientID, iObject, 0);
+			pub::Audio::PlaySoundEffect(iClientID, 2939827141); //CreateID("ui_select_remove")
+			return 0;
+		}
+	}
+
+	for (uint k = 0; k < Mark[iClientID].vDelayedSystemMarkedObjs.size(); k++)
+	{
+		if (Mark[iClientID].vDelayedSystemMarkedObjs[k] == iObject)
+		{
+			if (k != Mark[iClientID].vDelayedSystemMarkedObjs.size() - 1)
+			{
+				Mark[iClientID].vDelayedSystemMarkedObjs[k] = Mark[iClientID].vDelayedSystemMarkedObjs[Mark[iClientID].vDelayedSystemMarkedObjs.size() - 1];
+			}
+			Mark[iClientID].vDelayedSystemMarkedObjs.pop_back();
+			pub::Audio::PlaySoundEffect(iClientID, 2939827141); //CreateID("ui_select_remove")
+			return 0;
+		}
+	}
+	return 2;
+}
+
+void HkUnMarkAllObjects(uint iClientID)
+{
+	for (uint i = 0; i < Mark[iClientID].vMarkedObjs.size(); i++)
+	{
+		pub::Player::MarkObj(iClientID, (Mark[iClientID].vMarkedObjs[i]), 0);
+	}
+	Mark[iClientID].vMarkedObjs.clear();
+	for (uint i = 0; i < Mark[iClientID].vAutoMarkedObjs.size(); i++)
+	{
+		pub::Player::MarkObj(iClientID, (Mark[iClientID].vAutoMarkedObjs[i]), 0);
+	}
+	Mark[iClientID].vAutoMarkedObjs.clear();
+	Mark[iClientID].vDelayedSystemMarkedObjs.clear();
+	pub::Audio::PlaySoundEffect(iClientID, 2939827141); //CreateID("ui_select_remove")
+}
+
+std::string ftos(float f)
+{
+	char szBuf[16];
+	sprintf_s(szBuf, "%f", f);
+	return szBuf;
+}
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void ClearClientMark(uint iClientID)
+{
+	Mark[iClientID].bMarkEverything = false;
+	Mark[iClientID].vMarkedObjs.clear();
+	Mark[iClientID].vDelayedSystemMarkedObjs.clear();
+	Mark[iClientID].vAutoMarkedObjs.clear();
+	Mark[iClientID].vDelayedAutoMarkedObjs.clear();
+}
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//Timers
+void HkTimerSpaceObjMark()
+{
+	try {
+		if (set_fAutoMarkRadius <= 0.0f) //automarking disabled
+			return;
+
+		struct PlayerData* pPD = 0;
+		while (pPD = Players.traverse_active(pPD))
+		{
+			uint iShip, iClientID = HkGetClientIdFromPD(pPD);
+			pub::Player::GetShip(iClientID, iShip);
+			if (!iShip || Mark[iClientID].fAutoMarkRadius <= 0.0f) //docked or does not want any marking
+				continue;
+			uint iSystem;
+			pub::Player::GetSystem(iClientID, iSystem);
+			Vector VClientPos;
+			Matrix MClientOri;
+			pub::SpaceObj::GetLocation(iShip, VClientPos, MClientOri);
+
+			for (uint i = 0; i < Mark[iClientID].vAutoMarkedObjs.size(); i++)
+			{
+				Vector VTargetPos;
+				Matrix MTargetOri;
+				pub::SpaceObj::GetLocation(Mark[iClientID].vAutoMarkedObjs[i], VTargetPos, MTargetOri);
+				if (HkDistance3D(VTargetPos, VClientPos) > Mark[iClientID].fAutoMarkRadius)
+				{
+					pub::Player::MarkObj(iClientID, Mark[iClientID].vAutoMarkedObjs[i], 0);
+					Mark[iClientID].vDelayedAutoMarkedObjs.push_back(Mark[iClientID].vAutoMarkedObjs[i]);
+					if (i != Mark[iClientID].vAutoMarkedObjs.size() - 1)
+					{
+						Mark[iClientID].vAutoMarkedObjs[i] = Mark[iClientID].vAutoMarkedObjs[Mark[iClientID].vAutoMarkedObjs.size() - 1];
+						i--;
+					}
+					Mark[iClientID].vAutoMarkedObjs.pop_back();
+				}
+			}
+
+			for (uint i = 0; i < Mark[iClientID].vDelayedAutoMarkedObjs.size(); i++)
+			{
+				if (pub::SpaceObj::ExistsAndAlive(Mark[iClientID].vDelayedAutoMarkedObjs[i]))
+				{
+					if (i != Mark[iClientID].vDelayedAutoMarkedObjs.size() - 1)
+					{
+						Mark[iClientID].vDelayedAutoMarkedObjs[i] = Mark[iClientID].vDelayedAutoMarkedObjs[Mark[iClientID].vDelayedAutoMarkedObjs.size() - 1];
+						i--;
+					}
+					Mark[iClientID].vDelayedAutoMarkedObjs.pop_back();
+					continue;
+				}
+				Vector VTargetPos;
+				Matrix MTargetOri;
+				pub::SpaceObj::GetLocation(Mark[iClientID].vDelayedAutoMarkedObjs[i], VTargetPos, MTargetOri);
+				if (!(HkDistance3D(VTargetPos, VClientPos) > Mark[iClientID].fAutoMarkRadius))
+				{
+					pub::Player::MarkObj(iClientID, Mark[iClientID].vDelayedAutoMarkedObjs[i], 1);
+					Mark[iClientID].vAutoMarkedObjs.push_back(Mark[iClientID].vDelayedAutoMarkedObjs[i]);
+					if (i != Mark[iClientID].vDelayedAutoMarkedObjs.size() - 1)
+					{
+						Mark[iClientID].vDelayedAutoMarkedObjs[i] = Mark[iClientID].vDelayedAutoMarkedObjs[Mark[iClientID].vDelayedAutoMarkedObjs.size() - 1];
+						i--;
+					}
+					Mark[iClientID].vDelayedAutoMarkedObjs.pop_back();
+				}
+			}
+
+			for (uint i = 0; i < vMarkSpaceObjProc.size(); i++)
+			{
+				uint iMarkSpaceObjProcShip = vMarkSpaceObjProc[i];
+				if (set_bFlakVersion)
+				{
+					uint iType;
+					pub::SpaceObj::GetType(iMarkSpaceObjProcShip, iType);
+					if (iType != OBJ_CAPITAL && ((Mark[iClientID].bMarkEverything && iType == OBJ_FIGHTER)/* || iType==OBJ_FREIGHTER*/))
+					{
+						uint iSpaceObjSystem;
+						pub::SpaceObj::GetSystem(iMarkSpaceObjProcShip, iSpaceObjSystem);
+						Vector VTargetPos;
+						Matrix MTargetOri;
+						pub::SpaceObj::GetLocation(iMarkSpaceObjProcShip, VTargetPos, MTargetOri);
+						if (iSpaceObjSystem != iSystem || HkDistance3D(VTargetPos, VClientPos) > Mark[iClientID].fAutoMarkRadius)
+						{
+							Mark[iClientID].vDelayedAutoMarkedObjs.push_back(iMarkSpaceObjProcShip);
+						}
+						else
+						{
+							pub::Player::MarkObj(iClientID, iMarkSpaceObjProcShip, 1);
+							Mark[iClientID].vAutoMarkedObjs.push_back(iMarkSpaceObjProcShip);
+						}
+					}
+				}
+				else //just mark everything
+				{
+					uint iSpaceObjSystem;
+					pub::SpaceObj::GetSystem(iMarkSpaceObjProcShip, iSpaceObjSystem);
+					Vector VTargetPos;
+					Matrix MTargetOri;
+					pub::SpaceObj::GetLocation(iMarkSpaceObjProcShip, VTargetPos, MTargetOri);
+					if (iSpaceObjSystem != iSystem || HkDistance3D(VTargetPos, VClientPos) > Mark[iClientID].fAutoMarkRadius)
+					{
+						Mark[iClientID].vDelayedAutoMarkedObjs.push_back(iMarkSpaceObjProcShip);
+					}
+					else
+					{
+						pub::Player::MarkObj(iClientID, iMarkSpaceObjProcShip, 1);
+						Mark[iClientID].vAutoMarkedObjs.push_back(iMarkSpaceObjProcShip);
+					}
+				}
+			}
+			vMarkSpaceObjProc.clear();
+		}
+	}
+	catch (...) {}
+}
+
+std::list<DELAY_MARK> g_lstDelayedMarks;
+void HkTimerMarkDelay()
+{
+	if (!g_lstDelayedMarks.size())
+		return;
+
+	mstime tmTimeNow = timeInMS();
+	for (std::list<DELAY_MARK>::iterator mark = g_lstDelayedMarks.begin(); mark != g_lstDelayedMarks.end(); )
+	{
+		if (tmTimeNow - mark->time > 50)
+		{
+			Matrix mTemp;
+			Vector vItem, vPlayer;
+			pub::SpaceObj::GetLocation(mark->iObj, vItem, mTemp);
+			uint iItemSystem;
+			pub::SpaceObj::GetSystem(mark->iObj, iItemSystem);
+			// for all players
+			struct PlayerData* pPD = 0;
+			while (pPD = Players.traverse_active(pPD))
+			{
+				uint iClientID = HkGetClientIdFromPD(pPD);
+				if (Players[iClientID].iSystemID == iItemSystem)
+				{
+					pub::SpaceObj::GetLocation(Players[iClientID].iShipID, vPlayer, mTemp);
+					if (HkDistance3D(vPlayer, vItem) <= LOOT_UNSEEN_RADIUS)
+					{
+						HkMarkObject(iClientID, mark->iObj);
+					}
+				}
+			}
+			mark = g_lstDelayedMarks.erase(mark);
+		}
+		else
+		{
+			mark++;
+		}
+	}
+}
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+namespace HkIServerImpl
+{
+	EXPORT void __stdcall JumpInComplete(unsigned int iSystemID, unsigned int iShip)
+	{
+		uint iClientID = HkGetClientIDByShip(iShip);
+		if (!iClientID)
+			return;
+		std::vector<uint> vTempMark;
+		for (uint i = 0; i < Mark[iClientID].vDelayedSystemMarkedObjs.size(); i++)
+		{
+			if (pub::SpaceObj::ExistsAndAlive(Mark[iClientID].vDelayedSystemMarkedObjs[i]))
+			{
+				if (i != Mark[iClientID].vDelayedSystemMarkedObjs.size() - 1)
+				{
+					Mark[iClientID].vDelayedSystemMarkedObjs[i] = Mark[iClientID].vDelayedSystemMarkedObjs[Mark[iClientID].vDelayedSystemMarkedObjs.size() - 1];
+					i--;
+				}
+				Mark[iClientID].vDelayedSystemMarkedObjs.pop_back();
+				continue;
+			}
+
+			uint iTargetSystem;
+			pub::SpaceObj::GetSystem(Mark[iClientID].vDelayedSystemMarkedObjs[i], iTargetSystem);
+			if (iTargetSystem == iSystemID)
+			{
+				pub::Player::MarkObj(iClientID, Mark[iClientID].vDelayedSystemMarkedObjs[i], 1);
+				vTempMark.push_back(Mark[iClientID].vDelayedSystemMarkedObjs[i]);
+				if (i != Mark[iClientID].vDelayedSystemMarkedObjs.size() - 1)
+				{
+					Mark[iClientID].vDelayedSystemMarkedObjs[i] = Mark[iClientID].vDelayedSystemMarkedObjs[Mark[iClientID].vDelayedSystemMarkedObjs.size() - 1];
+					i--;
+				}
+				Mark[iClientID].vDelayedSystemMarkedObjs.pop_back();
+			}
+		}
+		for (uint i = 0; i < Mark[iClientID].vMarkedObjs.size(); i++)
+		{
+			if (!pub::SpaceObj::ExistsAndAlive(Mark[iClientID].vMarkedObjs[i]))
+				Mark[iClientID].vDelayedSystemMarkedObjs.push_back(Mark[iClientID].vMarkedObjs[i]);
+		}
+		Mark[iClientID].vMarkedObjs = vTempMark;
+	}
+
+	EXPORT void __stdcall LaunchComplete(unsigned int iBaseID, unsigned int iShip)
+	{
+		uint iClientID = HkGetClientIDByShip(iShip);
+		if (!iClientID)
+			return;
+		for (uint i = 0; i < Mark[iClientID].vMarkedObjs.size(); i++)
+		{
+			if (pub::SpaceObj::ExistsAndAlive(Mark[iClientID].vMarkedObjs[i]))
+			{
+				if (i != Mark[iClientID].vMarkedObjs.size() - 1)
+				{
+					Mark[iClientID].vMarkedObjs[i] = Mark[iClientID].vMarkedObjs[Mark[iClientID].vMarkedObjs.size() - 1];
+					i--;
+				}
+				Mark[iClientID].vMarkedObjs.pop_back();
+				continue;
+			}
+			pub::Player::MarkObj(iClientID, Mark[iClientID].vMarkedObjs[i], 1);
+		}
+	}
+
+	EXPORT void __stdcall BaseEnter(unsigned int iBaseID, unsigned int iClientID)
+	{
+		Mark[iClientID].vAutoMarkedObjs.clear();
+		Mark[iClientID].vDelayedAutoMarkedObjs.clear();
+	}
+
+	typedef void (*_TimerFunc)();
+	struct TIMER
+	{
+		_TimerFunc	proc;
+		mstime		tmIntervallMS;
+		mstime		tmLastCall;
+	};
+
+	TIMER Timers[] =
+	{
+		{HkTimerMarkDelay,			50,				0},
+		{HkTimerSpaceObjMark,		50,				0},
+	};
+
+	EXPORT int __stdcall Update()
+	{
+		returncode = DEFAULT_RETURNCODE;
+		static bool bFirstTime = true;
+		if (bFirstTime)
+		{
+			bFirstTime = false;
+			// check for logged in players and reset their connection data
+			struct PlayerData* pPD = 0;
+			while (pPD = Players.traverse_active(pPD))
+				ClearClientMark(HkGetClientIdFromPD(pPD));
+		}
+		for (uint i = 0; (i < sizeof(Timers) / sizeof(TIMER)); i++)
+		{
+			if ((timeInMS() - Timers[i].tmLastCall) >= Timers[i].tmIntervallMS)
+			{
+				Timers[i].tmLastCall = timeInMS();
+				Timers[i].proc();
+			}
+		}
+		return 0;
+	}
+}
+
+EXPORT void LoadUserCharSettings(uint iClientID)
+{
+	CAccount* acc = Players.FindAccountFromClientID(iClientID);
+	std::wstring wscDir;
+	HkGetAccountDirName(acc, wscDir);
+	std::string scUserFile = scAcctPath + wstos(wscDir) + "\\flhookuser.ini";
+	std::wstring wscFilename;
+	HkGetCharFileName(ARG_CLIENTID(iClientID), wscFilename);
+	std::string scFilename = wstos(wscFilename);
+	std::string scSection = "general_" + scFilename;
+	Mark[iClientID].bMarkEverything = IniGetB(scUserFile, scSection, "automarkenabled", false);
+	Mark[iClientID].bIgnoreGroupMark = IniGetB(scUserFile, scSection, "ignoregroupmarkenabled", false);
+	Mark[iClientID].fAutoMarkRadius = IniGetF(scUserFile, scSection, "automarkradius", set_fAutoMarkRadius);
+}
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+EXPORT void UserCmd_Help(uint iClientID, const std::wstring& wscParam)
+{
+	PrintUserCmdText(iClientID, L"/mark /m <--- Makes the selected object appear in the important section of the contacts and\n  have an arrow on the side of the screen, as well as have > and < on the sides\n  of the selection box.");
+	PrintUserCmdText(iClientID, L"/unmark /um <--- Unmarks the selected object marked with the /mark (/m) command.");
+	PrintUserCmdText(iClientID, L"/groupmark /gm <--- Marks selected object for the entire group.");
+	PrintUserCmdText(iClientID, L"/groupunmark /gum <--- Unmarks the selected object for the entire group.");
+	PrintUserCmdText(iClientID, L"/ignoregroupmarks <on|off> <--- Ignores marks from others in your group.");
+	PrintUserCmdText(iClientID, L"/automark <on|off> [radius in KM] <--- Automatically marks all ships in KM radius.  Bots are marked automatically in the\n  range specified whether on or off.  If you want to completely disable automarking,\n  set the radius to a number <= 0.");
+}
+
+USERCMD UserCmds[] =
+{
+	{ L"/mark",					        UserCmd_MarkObj},
+	{ L"/m",					        UserCmd_MarkObj},
+	{ L"/unmark",   					UserCmd_UnMarkObj},
+	{ L"/um",   					    UserCmd_UnMarkObj},
+	{ L"/unmarkall",					UserCmd_UnMarkAllObj},
+	{ L"/uma",					        UserCmd_UnMarkAllObj},
+	{ L"/groupmark",					UserCmd_MarkObjGroup},
+	{ L"/gm",					        UserCmd_MarkObjGroup},
+	{ L"/groupunmark",					UserCmd_UnMarkObjGroup},
+	{ L"/gum",					        UserCmd_UnMarkObjGroup},
+	{ L"/ignoregroupmarks",				UserCmd_SetIgnoreGroupMark},
+	{ L"/automark",					    UserCmd_AutoMark},
+};
+
+EXPORT bool UserCmd_Process(uint iClientID, const std::wstring& wscCmd)
+{
+	std::wstring wscCmdLower = ToLower(wscCmd);
+	for (uint i = 0; (i < sizeof(UserCmds) / sizeof(USERCMD)); i++)
+	{
+		if (wscCmdLower.find(ToLower(UserCmds[i].wszCmd)) == 0)
+		{
+			std::wstring wscParam = L"";
+			if (wscCmd.length() > wcslen(UserCmds[i].wszCmd))
+			{
+				if (wscCmd[wcslen(UserCmds[i].wszCmd)] != ' ')
+					continue;
+				wscParam = wscCmd.substr(wcslen(UserCmds[i].wszCmd) + 1);
+			}
+			UserCmds[i].proc(iClientID, wscParam);
+			returncode = SKIPPLUGINS_NOFUNCTIONCALL; // we handled the command, return immediatly
+			return true;
+		}
+	}
+	returncode = DEFAULT_RETURNCODE; // we did not handle the command, so let other plugins or FLHook kick in
+	return false;
+}
+
+EXPORT PLUGIN_INFO* Get_PluginInfo()
+{
+	PLUGIN_INFO* p_PI = new PLUGIN_INFO();
+	p_PI->sName = "Mark plugin by M0tah";
+	p_PI->sShortName = "mark";
+	p_PI->bMayPause = false;
+	p_PI->bMayUnload = false;
+	p_PI->ePluginReturnCode = &returncode;
+	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&UserCmd_Process, PLUGIN_UserCmd_Process, 0));
+	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&UserCmd_Help, PLUGIN_UserCmd_Help, 0));
+	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&HkIServerImpl::JumpInComplete, PLUGIN_HkIServerImpl_JumpInComplete, 0));
+	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&HkIServerImpl::LaunchComplete, PLUGIN_HkIServerImpl_LaunchComplete, 0));
+	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&HkIServerImpl::BaseEnter, PLUGIN_HkIServerImpl_BaseEnter, 0));
+	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&HkIServerImpl::Update, PLUGIN_HkIServerImpl_Update, 0));
+	p_PI->lstHooks.push_back(PLUGIN_HOOKINFO((FARPROC*)&LoadUserCharSettings, PLUGIN_LoadUserCharSettings, 0));
+	return p_PI;
+}

--- a/plugins/mark_plugin/Main.h
+++ b/plugins/mark_plugin/Main.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <windows.h>
+#include <stdio.h>
+#include <string>
+#include <time.h>
+#include <math.h>
+#include <list>
+#include <map>
+#include <algorithm>
+#include <FLHook.h>
+#include <plugin.h>
+#include "PluginUtilities.h"
+
+static int set_iPluginDebug = 0;
+PLUGIN_RETURNCODE returncode;
+
+typedef void (*_UserCmdProc)(uint, const std::wstring&);
+
+struct USERCMD
+{
+    wchar_t* wszCmd;
+    _UserCmdProc proc;
+};
+
+#define IS_CMD(a) !wscCmd.compare(L##a)
+
+void AddExceptionInfoLog(struct SEHException* pep);
+
+void ClearClientMark(uint iClientID);
+void HkUnMarkAllObjects(uint iClientID);
+char HkUnMarkObject(uint iClientID, uint iObject);
+char HkMarkObject(uint iClientID, uint iObject);
+
+struct MARK_INFO
+{
+    bool bMarkEverything;
+    bool bIgnoreGroupMark;
+    float fAutoMarkRadius;
+    std::vector<uint> vMarkedObjs;
+    std::vector<uint> vDelayedSystemMarkedObjs;
+    std::vector<uint> vAutoMarkedObjs;
+    std::vector<uint> vDelayedAutoMarkedObjs;
+};
+
+struct DELAY_MARK { uint iObj; mstime time; };
+std::string ftos(float f);

--- a/plugins/mark_plugin/PluginUtilities.cpp
+++ b/plugins/mark_plugin/PluginUtilities.cpp
@@ -1,0 +1,704 @@
+// Player Control plugin for FLHookPlugin
+// Feb 2010 by Cannon
+//
+// This is free software; you can redistribute it and/or modify it as
+// you wish without restriction. If you do then I would appreciate
+// being notified and/or mentioned somewhere.
+
+#include <windows.h>
+#include <stdio.h>
+#include <string>
+#include <time.h>
+#include <math.h>
+#include <float.h>
+#include <list>
+#include <FLHook.h>
+#include <plugin.h>
+#include <FLCoreRemoteClient.h>
+#include "PluginUtilities.h"
+
+#include <io.h>
+#include <shlwapi.h>
+
+#include <Psapi.h>
+
+#define ADDR_RMCLIENT_LAUNCH 0x5B40
+#define ADDR_RMCLIENT_CLIENT 0x43D74
+
+//Player in-system beaming
+struct LAUNCH_PACKET
+{
+	uint iShip;
+	uint iDunno[2];
+	float fRotate[4];
+	float fPos[3];
+};
+
+/** Calculate the distance between the two vectors */
+float HkDistance3D(Vector v1, Vector v2)
+{
+	float sq1 = v1.x-v2.x, sq2 = v1.y-v2.y, sq3 = v1.z-v2.z;
+	return sqrt( sq1*sq1 + sq2*sq2 + sq3*sq3 );
+}
+
+/** Send a temp ban request to the tempban plugin */
+void HkTempBan(uint client, uint iDuration)
+{
+	// call tempban plugin
+	TEMPBAN_BAN_STRUCT tempban;
+	tempban.iClientID = client;
+	tempban.iDuration = iDuration; 
+	Plugin_Communication(TEMPBAN_BAN,&tempban);
+}
+
+/** Instructs DSAce to change an IDS std::string */
+void HkChangeIDSString(uint client, uint ids, const std::wstring &text)
+{
+	DSACE_CHANGE_INFOCARD_STRUCT info;
+	info.iClientID = client;
+	info.ids = ids; 
+	info.text = text;
+	Plugin_Communication(DSACE_CHANGE_INFOCARD, &info);
+}
+
+Quaternion HkMatrixToQuaternion(Matrix m)
+{
+	Quaternion quaternion;
+	quaternion.w = sqrt( max( 0, 1 + m.data[0][0] + m.data[1][1] + m.data[2][2] ) ) / 2; 
+	quaternion.x = sqrt( max( 0, 1 + m.data[0][0] - m.data[1][1] - m.data[2][2] ) ) / 2; 
+	quaternion.y = sqrt( max( 0, 1 - m.data[0][0] + m.data[1][1] - m.data[2][2] ) ) / 2; 
+	quaternion.z = sqrt( max( 0, 1 - m.data[0][0] - m.data[1][1] + m.data[2][2] ) ) / 2; 
+	quaternion.x = (float)_copysign( quaternion.x, m.data[2][1] - m.data[1][2] );
+	quaternion.y = (float)_copysign( quaternion.y, m.data[0][2] - m.data[2][0] );
+	quaternion.z = (float)_copysign( quaternion.z, m.data[1][0] - m.data[0][1] );
+	return quaternion;
+}
+
+/** Move the client to the specified location */
+void HkRelocateClient(uint client, Vector vDestination, Matrix mOrientation) 
+{
+	Quaternion qRotation = HkMatrixToQuaternion(mOrientation);
+
+	FLPACKET_LAUNCH pLaunch;
+	pLaunch.iShip = ClientInfo[client].iShip;
+	pLaunch.iBase = 0;
+	pLaunch.iState = 0xFFFFFFFF;
+	pLaunch.fRotate[0] = qRotation.w;
+	pLaunch.fRotate[1] = qRotation.x;
+	pLaunch.fRotate[2] = qRotation.y;
+	pLaunch.fRotate[3] = qRotation.z;
+	pLaunch.fPos[0] = vDestination.x;
+	pLaunch.fPos[1] = vDestination.y;
+	pLaunch.fPos[2] = vDestination.z;
+
+	HookClient->Send_FLPACKET_SERVER_LAUNCH(client, pLaunch);
+
+	uint iSystem;
+	pub::Player::GetSystem(client, iSystem);
+	pub::SpaceObj::Relocate(ClientInfo[client].iShip, iSystem, vDestination, mOrientation);
+}
+
+/** Dock the client immediately */
+HK_ERROR HkInstantDock(uint client, uint iDockObj)
+{
+	// check if logged in
+	if(client == -1)
+		return HKE_PLAYER_NOT_LOGGED_IN;
+
+	uint iShip;
+	pub::Player::GetShip(client, iShip);
+	if(!iShip)
+		return HKE_PLAYER_NOT_IN_SPACE;
+
+	uint iSystem, iSystem2;
+	pub::SpaceObj::GetSystem(iShip, iSystem);
+	pub::SpaceObj::GetSystem(iDockObj, iSystem2);
+	if(iSystem!=iSystem2)
+	{
+		return HKE_PLAYER_NOT_IN_SPACE;
+	}
+
+	try {
+		pub::SpaceObj::InstantDock(iShip, iDockObj, 1);
+	} catch(...) { return HKE_PLAYER_NOT_IN_SPACE; }
+
+	return HKE_OK;
+}
+
+HK_ERROR HkGetRank(const std::wstring &charname, int &iRank)
+{
+	HK_ERROR err;
+	std::wstring wscRet = L"";
+	if ((err = HkFLIniGet(charname, L"rank", wscRet)) != HKE_OK)
+		return err;
+	if (wscRet.length())
+		iRank = ToInt(wscRet);
+	else
+		iRank = 0;
+	return HKE_OK;
+}
+
+/// Get online time.
+HK_ERROR HkGetOnLineTime(const std::wstring &charname, int &iSecs)
+{
+	std::wstring wscDir;
+	if(!HKHKSUCCESS(HkGetAccountDirName(charname, wscDir)))
+		return HKE_CHAR_DOES_NOT_EXIST;
+
+	std::wstring wscFile;
+	HkGetCharFileName(charname, wscFile);
+
+	std::string scCharFile  = scAcctPath + wstos(wscDir) + "\\" + wstos(wscFile) + ".fl";
+	if (HkIsEncoded(scCharFile))
+	{
+		std::string scCharFileNew = scCharFile + ".ini";
+		if (!flc_decode(scCharFile.c_str(), scCharFileNew.c_str()))
+			return HKE_COULD_NOT_DECODE_CHARFILE;
+
+		iSecs = (int)IniGetF(scCharFileNew, "mPlayer", "total_time_played", 0.0f);
+		DeleteFile(scCharFileNew.c_str());
+	}
+	else
+	{
+		iSecs = (int)IniGetF(scCharFile, "mPlayer", "total_time_played", 0.0f);
+	}
+
+	return HKE_OK;
+}
+
+/**
+This function is similar to GetParam but instead returns everything
+from the parameter specified by iPos to the end of wscLine.
+
+wscLine - the std::string to get parameters from
+wcSplitChar - the seperator character
+iPos - the parameter number to start from.
+*/
+std::wstring GetParamToEnd(const std::wstring &wscLine, wchar_t wcSplitChar, uint iPos)
+{
+	for(uint i = 0, j = 0; (i <= iPos) && (j < wscLine.length()); j++)
+	{
+		if(wscLine[j] == wcSplitChar)
+		{
+			while(((j + 1) < wscLine.length()) && (wscLine[j+1] == wcSplitChar))
+				j++; // skip "whitechar"
+			i++;
+			continue;
+		}
+		if	(i == iPos)
+		{
+			return wscLine.substr(j);
+		}
+	}
+	return L"";
+}
+
+
+std::string GetParam(std::string scLine, char cSplitChar, uint iPos)
+{
+	uint i = 0, j = 0;
+
+	std::string scResult = "";
+	for(i = 0, j = 0; (i <= iPos) && (j < scLine.length()); j++)
+	{
+		if(scLine[j] == cSplitChar)
+		{
+			while(((j + 1) < scLine.length()) && (scLine[j+1] == cSplitChar))
+				j++; // skip "whitechar"
+
+			i++;
+			continue;
+		}
+
+		if(i == iPos)
+			scResult += scLine[j];
+	}
+
+	return scResult;
+}
+
+
+/**
+Determine the path name of a file in the charname account directory with the
+provided extension. The resulting path is returned in the path parameter.
+*/
+std::string GetUserFilePath(const std::wstring &charname)
+{
+	// init variables
+	char datapath[MAX_PATH];
+	GetUserDataPath(datapath);
+	std::string scAcctPath = std::string(datapath) + "\\Accts\\MultiPlayer\\";
+
+	std::wstring wscDir;
+	std::wstring wscFile;
+	if (HkGetAccountDirName(charname, wscDir)!=HKE_OK)
+		return "";
+	if (HkGetCharFileName(charname, wscFile)!=HKE_OK)
+		return "";
+
+	return scAcctPath + wstos(wscDir) + "\\" + wstos(wscFile) + ".fl";
+}
+
+/** This function is not exported by FLHook so we include it here */
+HK_ERROR HkFMsgEncodeMsg(const std::wstring &wscMessage, char *szBuf, uint iSize, uint &iRet)
+{
+	XMLReader rdr;
+	RenderDisplayList rdl;
+	std::wstring wscMsg = L"<?xml version=\"1.0\" encoding=\"UTF-16\"?><RDL><PUSH/>";
+	wscMsg += L"<TRA data=\"0xE6C68400\" mask=\"-1\"/><TEXT>" + XMLText(wscMessage) + L"</TEXT>";
+	wscMsg += L"<PARA/><POP/></RDL>\x000A\x000A";
+	if(!rdr.read_buffer(rdl, (const char*)wscMsg.c_str(), (uint)wscMsg.length() * 2))
+		return HKE_WRONG_XML_SYNTAX;
+
+	BinaryRDLWriter	rdlwrite;
+	rdlwrite.write_buffer(rdl, szBuf, iSize, iRet);
+
+	return HKE_OK;
+}
+
+int ToInt(const std::string &scStr)
+{
+	return atoi(scStr.c_str());
+}
+
+std::string itohexs(uint value)
+{
+	char buf[16];
+	sprintf(buf, "%08X", value);
+	return buf;
+}
+
+/// Print message to all ships within the specific number of meters of the player.
+void PrintLocalUserCmdText(uint client, const std::wstring &wscMsg, float fDistance)
+{
+	uint iShip;
+	pub::Player::GetShip(client, iShip);
+
+	Vector pos;
+	Matrix rot;
+	pub::SpaceObj::GetLocation(iShip, pos, rot);
+
+	uint iSystem;
+	pub::Player::GetSystem(client, iSystem);
+
+	// For all players in system...
+	struct PlayerData *pPD = 0;
+	while(pPD = Players.traverse_active(pPD))
+	{
+		// Get the this player's current system and location in the system.
+		uint client2 = HkGetClientIdFromPD(pPD);
+		uint iSystem2 = 0;
+		pub::Player::GetSystem(client2, iSystem2);
+		if (iSystem != iSystem2)
+			continue;
+
+		uint iShip2;
+		pub::Player::GetShip(client2, iShip2);
+
+		Vector pos2;
+		Matrix rot2;
+		pub::SpaceObj::GetLocation(iShip2, pos2, rot2);
+
+		// Is player within the specified range of the sending char.
+		if (HkDistance3D(pos, pos2) > fDistance)
+			continue;
+
+		PrintUserCmdText(client2, L"%s", wscMsg.c_str());
+	}
+}
+
+
+/// Return true if this player is within the specified distance of any other player.
+bool IsInRange(uint client, float fDistance)
+{
+	std::list<GROUP_MEMBER> lstMembers;
+	HkGetGroupMembers((const wchar_t*) Players.GetActiveCharacterName(client), lstMembers);
+
+	uint iShip;
+	pub::Player::GetShip(client, iShip);
+
+	Vector pos;
+	Matrix rot;
+	pub::SpaceObj::GetLocation(iShip, pos, rot);
+
+	uint iSystem;
+	pub::Player::GetSystem(client, iSystem);
+
+	// For all players in system...
+	struct PlayerData *pPD = 0;
+	while(pPD = Players.traverse_active(pPD))
+	{
+		// Get the this player's current system and location in the system.
+		uint client2 = HkGetClientIdFromPD(pPD);
+		uint iSystem2 = 0;
+		pub::Player::GetSystem(client2, iSystem2);
+		if (iSystem != iSystem2)
+			continue;
+
+		uint iShip2;
+		pub::Player::GetShip(client2, iShip2);
+
+		Vector pos2;
+		Matrix rot2;
+		pub::SpaceObj::GetLocation(iShip2, pos2, rot2);
+
+		// Ignore players who are in your group.
+		bool bGrouped = false;
+		for(auto& gm : lstMembers)
+		{
+			if (gm.iClientID==client2)
+			{
+				bGrouped = true;
+				break;
+			}
+		}
+		if (bGrouped)
+			continue;
+
+		// Is player within the specified range of the sending char.
+		if (HkDistance3D(pos, pos2) < fDistance)
+			return true;
+	}
+	return false;
+}
+
+/**
+Remove leading and trailing spaces from the std::string ~FlakCommon by Motah.
+*/
+std::wstring Trim(std::wstring wscIn)
+{
+	while(wscIn.length() && (wscIn[0]==L' ' || wscIn[0]==L'	' || wscIn[0]==L'\n' || wscIn[0]==L'\r') )
+	{
+		wscIn = wscIn.substr(1);
+	}
+	while(wscIn.length() && (wscIn[wscIn.length()-1]==L' ' || wscIn[wscIn.length()-1]==L'	' || wscIn[wscIn.length()-1]==L'\n' || wscIn[wscIn.length()-1]==L'\r') )
+	{
+		wscIn = wscIn.substr(0, wscIn.length()-1);
+	}
+	return wscIn;
+}
+
+/**
+Remove leading and trailing spaces from the std::string  ~FlakCommon by Motah.
+*/
+std::string Trim(std::string scIn)
+{
+	while(scIn.length() && (scIn[0]==' ' || scIn[0]=='	' || scIn[0]=='\n' || scIn[0]=='\r') )
+	{
+		scIn = scIn.substr(1);
+	}
+	while(scIn.length() && (scIn[scIn.length()-1]==L' ' || scIn[scIn.length()-1]=='	' || scIn[scIn.length()-1]=='\n' || scIn[scIn.length()-1]=='\r') )
+	{
+		scIn = scIn.substr(0, scIn.length()-1);
+	}
+	return scIn;
+}
+
+std::wstring GetTimeString(bool bLocalTime)
+{
+	SYSTEMTIME st;
+	if (bLocalTime)
+		GetLocalTime(&st);
+	else
+		GetSystemTime(&st);
+
+	wchar_t wszBuf[100];
+	_snwprintf_s(wszBuf, sizeof(wszBuf), L"%04d-%02d-%02d %02d:%02d:%02d SMT ", st.wYear, st.wMonth, st.wDay, 
+		st.wHour, st.wMinute, st.wSecond);
+	return wszBuf;
+}
+
+std::wstring GetLocation(unsigned int client)
+{
+	uint iSystemID = 0;
+	uint iShip = 0;
+	pub::Player::GetSystem(client, iSystemID);
+	pub::Player::GetShip(client, iShip);
+	if (!iSystemID || !iShip)
+	{
+		PrintUserCmdText(client, L"ERR Not in space");
+		return false;
+	}
+
+	Vector pos;
+	Matrix rot;
+	pub::SpaceObj::GetLocation(iShip, pos, rot);
+
+	float scale = 1.0;
+	const Universe::ISystem *iSystem = Universe::get_system(iSystemID);
+	if (iSystem)
+		scale = iSystem->NavMapScale;
+
+	float fGridsize = 34000.0f / scale;
+	int gridRefX = (int)((pos.x + (fGridsize * 5)) / fGridsize) - 1;
+	int gridRefZ = (int)((pos.z + (fGridsize * 5)) / fGridsize) - 1;
+
+	std::wstring wscXPos = L"X";
+	if (gridRefX >= 0 && gridRefX < 8)
+	{
+		wchar_t* gridXLabel[] = {L"A", L"B", L"C", L"D", L"E", L"F", L"G", L"H"};
+		wscXPos = gridXLabel[gridRefX];
+	}
+
+	std::wstring wscZPos = L"X";
+	if (gridRefZ >= 0 && gridRefZ < 8)
+	{
+		wchar_t* gridZLabel[] = {L"1", L"2", L"3", L"4", L"5", L"6", L"7", L"8"};
+		wscZPos = gridZLabel[gridRefZ];
+	}
+
+	wchar_t wszCurrentLocation[100];
+	_snwprintf(wszCurrentLocation, sizeof(wszCurrentLocation), L"%s-%s", wscXPos.c_str(), wscZPos.c_str());
+	return wszCurrentLocation;
+}
+
+uint HkGetClientIDFromArg(const std::wstring &wscArg)
+{
+	uint client;
+
+	if (HkResolveId(wscArg, client) == HKE_OK)
+		return client;
+
+	if (HkResolveShortCut(wscArg, client) == HKE_OK)
+		return client;
+
+	return HkGetClientIdFromCharname(wscArg);
+}
+
+
+/// Return the CEqObj from the IObjRW
+__declspec(naked) CEqObj * __stdcall HkGetEqObjFromObjRW(struct IObjRW *objRW)
+{
+   __asm
+   {
+      push ecx
+      push edx
+      mov ecx, [esp+12]
+      mov edx, [ecx]
+      call dword ptr[edx+0x150]
+      pop edx
+      pop ecx
+      ret 4
+   }
+}
+
+__declspec(naked) void __stdcall HkLightFuse(IObjRW *ship, uint iFuseID, float fDelay, float fLifetime, float fSkip)
+{
+	__asm
+	{
+		lea eax, [esp+8] //iFuseID
+		push [esp+20] //fSkip
+		push [esp+16] //fDelay
+		push 0 //SUBOBJ_ID_NONE
+		push eax
+		push [esp+32] //fLifetime
+		mov ecx, [esp+24]
+		mov eax, [ecx]
+		call [eax+0x1E4]
+		ret 20
+	}
+}
+
+__declspec(naked) void __stdcall HkUnLightFuse(IObjRW *ship, uint iFuseID, float fDunno)
+{
+	__asm
+	{
+		mov ecx, [esp+4]
+		lea eax, [esp+8] //iFuseID
+		push [esp+12] //fDunno
+		push 0 //SUBOBJ_ID_NONE
+		push eax //iFuseID
+		mov eax, [ecx]
+		call [eax+0x1E8]
+		ret 12
+	}
+}
+
+
+std::vector<HINSTANCE> vDLLs;
+
+void HkLoadStringDLLs()
+{
+	HkUnloadStringDLLs();
+
+	HINSTANCE hDLL = LoadLibraryEx("resources.dll", NULL, LOAD_LIBRARY_AS_DATAFILE); //typically resources.dll
+	if(hDLL)
+		vDLLs.push_back(hDLL);
+	
+	INI_Reader ini;
+	if (ini.open("freelancer.ini", false))
+	{
+		while (ini.read_header())
+		{
+			if (ini.is_header("Resources"))
+			{
+				while (ini.read_value())
+				{
+					if (ini.is_value("DLL"))
+					{
+						hDLL = LoadLibraryEx(ini.get_value_string(0), NULL, LOAD_LIBRARY_AS_DATAFILE);
+						if (hDLL)
+							vDLLs.push_back(hDLL);
+					}
+				}
+			}
+		}
+		ini.close();
+	}
+}
+
+void HkUnloadStringDLLs()
+{
+	for (uint i=0; i<vDLLs.size(); i++)
+		FreeLibrary(vDLLs[i]);
+	vDLLs.clear();
+}
+
+std::wstring HkGetWStringFromIDS(uint iIDS)
+{
+	wchar_t wszBuf[1024];
+	if (LoadStringW(vDLLs[iIDS >> 16], iIDS & 0xFFFF, wszBuf, 1024))
+		return wszBuf;
+	return L"";
+}
+
+CAccount* HkGetAccountByClientID(uint client)
+{
+	if (!HkIsValidClientID(client))
+		return 0;
+
+	return Players.FindAccountFromClientID(client);
+}
+
+std::wstring HkGetAccountIDByClientID(uint client)
+{
+	if (HkIsValidClientID(client))
+	{
+		CAccount *acc = HkGetAccountByClientID(client);
+		if (acc && acc->wszAccID)
+		{
+			wchar_t buf[35];
+			wcsncpy_s(buf, 35, acc->wszAccID, 35); 
+			return buf;
+		}
+	}
+	return L"";
+}
+
+void HkDelayedKick(uint client, uint secs)
+{
+	mstime kick_time = timeInMS() + (secs * 1000);
+	if (!ClientInfo[client].tmKickTime || ClientInfo[client].tmKickTime > kick_time)
+		ClientInfo[client].tmKickTime = kick_time;
+}
+
+
+#define PI 3.14159265f
+
+// Convert radians to degrees.
+float degrees( float rad )
+{
+  rad *= 180 / PI;
+
+  // Prevent displaying -0 and prefer 180 to -180.
+  if (rad < 0)
+  {
+    if (rad > -0.005f)
+      rad = 0;
+    else if (rad <= -179.995f)
+      rad = 180;
+  }
+
+  // Round to two decimal places here, so %g can display it without decimals.
+  float frac = modff( rad * 100, &rad );
+  if (frac >= 0.5f)
+    ++rad;
+  else if (frac <= -0.5f)
+    --rad;
+
+  return rad / 100;
+}
+
+// Convert an orientation matrix to a pitch/yaw/roll vector.  Based on what
+// Freelancer does for the save game.
+Vector MatrixToEuler(const Matrix& mat)
+{
+	Vector x = { mat.data[0][0], mat.data[1][0], mat.data[2][0] };
+	Vector y = { mat.data[0][1], mat.data[1][1], mat.data[2][1] };
+	Vector z = { mat.data[0][2], mat.data[1][2], mat.data[2][2] };
+
+	Vector vec;
+	float h = (float)_hypot( x.x, x.y );
+	if (h > 1/524288.0f)
+	{
+		vec.x = degrees( atan2f(  y.z, z.z ) );
+		vec.y = degrees( atan2f( -x.z, h   ) );
+		vec.z = degrees( atan2f(  x.y, x.x ) );
+	}
+	else
+	{
+		vec.x = degrees( atan2f( -z.y, y.y ) );
+		vec.y = degrees( atan2f( -x.z, h   ) );
+		vec.z = 0;
+	}
+	return vec;
+}
+
+void ini_write_wstring(FILE *file, const std::string &parmname, const std::wstring &in)
+{
+	fprintf(file, "%s=", parmname.c_str()); 
+	for (int i = 0; i < (int)in.size(); i++)
+	{
+		UINT v1 = in[i] >> 8;
+		UINT v2 = in[i] & 0xFF;
+		fprintf(file, "%02x%02x", v1, v2); 
+	}
+	fprintf(file, "\n");
+}
+
+
+void ini_get_wstring(INI_Reader &ini, std::wstring &wscValue)
+{
+	std::string scValue = ini.get_value_string();
+	wscValue = L"";
+	long lHiByte;
+	long lLoByte;
+	while(sscanf(scValue.c_str(), "%02X%02X", &lHiByte, &lLoByte) == 2)
+	{
+		scValue = scValue.substr(4);
+		wchar_t wChar = (wchar_t)((lHiByte << 8) | lLoByte);
+		wscValue.append(1, wChar);
+	}
+}
+
+
+void Rotate180(Matrix &rot)
+{
+	rot.data[0][0] = -rot.data[0][0];
+	rot.data[1][0] = -rot.data[1][0];
+	rot.data[2][0] = -rot.data[2][0];
+	rot.data[0][2] = -rot.data[0][2];
+	rot.data[1][2] = -rot.data[1][2];
+	rot.data[2][2] = -rot.data[2][2];
+}
+
+void TranslateY(Vector &pos, Matrix &rot, float y)
+{
+	pos.x += y * rot.data[0][0];
+	pos.y += y * rot.data[1][0];
+	pos.z += y * rot.data[2][0];
+}
+
+void TranslateX(Vector &pos, Matrix &rot, float x)
+{
+	pos.x += x * rot.data[0][2];
+	pos.y += x * rot.data[1][2];
+	pos.z += x * rot.data[2][2];
+}
+
+void TranslateZ(Vector &pos, Matrix &rot, float z)
+{
+	pos.x += z * rot.data[0][1];
+	pos.y += z * rot.data[1][1];
+	pos.z += z * rot.data[2][1];
+}

--- a/plugins/mark_plugin/PluginUtilities.h
+++ b/plugins/mark_plugin/PluginUtilities.h
@@ -1,0 +1,77 @@
+// Player Control plugin for FLHookPlugin
+// Feb 2010 by Cannon
+//
+// This is free software; you can redistribute it and/or modify it as
+// you wish without restriction. If you do then I would appreciate
+// being notified and/or mentioned somewhere.
+
+
+#ifndef __PluginUtilities_H__
+#define __PluginUtilities_H__ 1
+
+float HkDistance3D(Vector v1, Vector v2);
+Quaternion HkMatrixToQuaternion(Matrix m);
+void HkTempBan(uint client, uint iDuration);
+void HkRelocateClient(uint client, Vector vDestination, Matrix mOrientation);
+HK_ERROR HkInstantDock(uint client, uint iDockObj);
+HK_ERROR HkFMsgEncodeMsg(const std::wstring &wscMessage, char *szBuf, uint iSize, uint &iRet);
+HK_ERROR HkGetRank(const std::wstring &wscCharname, int &iRank);
+HK_ERROR HkGetOnLineTime(const std::wstring &wscCharname, int &iSecs);
+
+std::wstring GetParamToEnd(const std::wstring &wscLine, wchar_t wcSplitChar, uint iPos);
+std::string GetParam(std::string scLine, char cSplitChar, uint iPos);
+std::string GetUserFilePath(const std::wstring &wscCharname);
+std::wstring Trim(std::wstring wscIn);
+std::string Trim(std::string scIn);
+int ToInt(const std::string &scStr);
+
+std::string itohexs(uint value);
+
+/// Print message to all ships within the specific number of meters of the player.
+void PrintLocalUserCmdText(uint client, const std::wstring &wscMsg, float fDistance);
+
+/// Return true if this player is within the specified distance of any other player.
+bool IsInRange(uint client, float fDistance);
+
+/// Return the current time as a string
+std::wstring GetTimeString(bool bLocalTime);
+
+/// Message to DSAce to change a client string.
+void HkChangeIDSString(uint client, uint ids, const std::wstring &text);
+
+/// Return the ship location in nav-map coordinates
+std::wstring GetLocation(unsigned int client);
+
+uint HkGetClientIDFromArg(const std::wstring &wscArg);
+
+CEqObj * __stdcall HkGetEqObjFromObjRW(struct IObjRW *objRW);
+
+void __stdcall HkLightFuse(IObjRW *ship, uint iFuseID, float fDelay, float fLifetime, float fSkip);
+void __stdcall HkUnLightFuse(IObjRW *ship, uint iFuseID, float fDunno);
+
+void HkLoadStringDLLs();
+void HkUnloadStringDLLs();
+std::wstring HkGetWStringFromIDS(uint iIDS);
+
+void AddExceptionInfoLog();
+#define LOG_EXCEPTION { AddLog("ERROR Exception in %s", __FUNCTION__); AddExceptionInfoLog(); }
+
+CAccount* HkGetAccountByClientID(uint client);
+std::wstring HkGetAccountIDByClientID(uint client);
+
+void HkDelayedKick(uint client, uint secs);
+
+float degrees( float rad );
+
+// Convert an orientation matrix to a pitch/yaw/roll vector.  Based on what
+// Freelancer does for the save game.
+Vector MatrixToEuler(const Matrix& mat);
+void ini_write_wstring(FILE *file, const std::string &parmname, const std::wstring &in);
+void ini_get_wstring(INI_Reader &ini, std::wstring &wscValue);
+
+void Rotate180(Matrix &rot);
+void TranslateX(Vector &pos, Matrix &rot, float x);
+void TranslateY(Vector &pos, Matrix &rot, float y);
+void TranslateZ(Vector &pos, Matrix &rot, float z);
+
+#endif

--- a/plugins/mark_plugin/mark.cfg
+++ b/plugins/mark_plugin/mark.cfg
@@ -1,0 +1,2 @@
+[General]
+AutoMarkRadius=-1

--- a/plugins/mark_plugin/mark_plugin.ini
+++ b/plugins/mark_plugin/mark_plugin.ini
@@ -1,0 +1,2 @@
+[General]
+debug = 0

--- a/plugins/mark_plugin/mark_plugin.ini
+++ b/plugins/mark_plugin/mark_plugin.ini
@@ -1,2 +1,0 @@
-[General]
-debug = 0

--- a/plugins/mark_plugin/mark_plugin.vcxproj
+++ b/plugins/mark_plugin/mark_plugin.vcxproj
@@ -47,7 +47,7 @@
     <TargetName>mark_plugin</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <TargetName>mark_plugin</TargetName>
+    <TargetName>mark</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/plugins/mark_plugin/mark_plugin.vcxproj
+++ b/plugins/mark_plugin/mark_plugin.vcxproj
@@ -1,0 +1,76 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{14C91A47-44A3-4D90-99C3-BFFA10491A56}</ProjectGuid>
+    <RootNamespace>mark</RootNamespace>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <ProjectName>Mark Plugin</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+    <Import Project="..\..\project\Common.props" />
+    <Import Project="..\Plugin Common.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+    <Import Project="..\..\project\Common.props" />
+    <Import Project="..\Plugin Common.props" />
+  </ImportGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <TargetName>mark_plugin</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <TargetName>mark_plugin</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="Main.cpp" />
+    <ClCompile Include="PluginUtilities.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\project\FLHook.vcxproj">
+      <Project>{fe6eb3c9-da22-4492-aec3-068c9553a623}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Main.h" />
+    <ClInclude Include="PluginUtilities.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="mark_plugin.ini" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/plugins/mark_plugin/mark_plugin.vcxproj
+++ b/plugins/mark_plugin/mark_plugin.vcxproj
@@ -68,7 +68,7 @@
     <ClInclude Include="PluginUtilities.h" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="mark_plugin.ini" />
+    <None Include="mark.cfg" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/project/FLHook.sln
+++ b/project/FLHook.sln
@@ -34,6 +34,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Kill Counter Plugin", "..\p
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "AFK Plugin", "..\plugins\afk_plugin\AFK Plugin.vcxproj", "{18322D6B-43B1-49D8-A2FD-8C55EB4524AE}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Mark Plugin", "..\plugins\mark_plugin\mark_plugin.vcxproj", "{14C91A47-44A3-4D90-99C3-BFFA10491A56}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Win32 = Debug|Win32
@@ -125,6 +127,12 @@ Global
 		{18322D6B-43B1-49D8-A2FD-8C55EB4524AE}.Release|Win32.Build.0 = Release|Win32
 		{18322D6B-43B1-49D8-A2FD-8C55EB4524AE}.ReleaseVersion|Win32.ActiveCfg = Release|Win32
 		{18322D6B-43B1-49D8-A2FD-8C55EB4524AE}.ReleaseVersion|Win32.Build.0 = Release|Win32
+		{14C91A47-44A3-4D90-99C3-BFFA10491A56}.Debug|Win32.ActiveCfg = Debug|Win32
+		{14C91A47-44A3-4D90-99C3-BFFA10491A56}.Debug|Win32.Build.0 = Debug|Win32
+		{14C91A47-44A3-4D90-99C3-BFFA10491A56}.Release|Win32.ActiveCfg = Release|Win32
+		{14C91A47-44A3-4D90-99C3-BFFA10491A56}.Release|Win32.Build.0 = Release|Win32
+		{14C91A47-44A3-4D90-99C3-BFFA10491A56}.ReleaseVersion|Win32.ActiveCfg = Release|Win32
+		{14C91A47-44A3-4D90-99C3-BFFA10491A56}.ReleaseVersion|Win32.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -143,6 +151,7 @@ Global
 		{7D50A30F-3838-4FB7-9966-FD8748E4BE1D} = {632FB3BE-F949-4FDF-8EDC-DA5433451E34}
 		{0B2F0DB4-D231-43E7-8FDF-EF311DE6BBC9} = {88754785-84CA-4F78-8906-F8C39564BA83}
 		{18322D6B-43B1-49D8-A2FD-8C55EB4524AE} = {88754785-84CA-4F78-8906-F8C39564BA83}
+		{14C91A47-44A3-4D90-99C3-BFFA10491A56} = {88754785-84CA-4F78-8906-F8C39564BA83}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BAC9ADCA-E201-4AA0-8494-1C3804461C24}


### PR DESCRIPTION
Ported from M0tah's plugin

**/mark /m**
Makes the selected object appear in the important section of the contacts and have an arrow on the side of the screen, as well as have > and < on the sides of the selection box.

**unmark /um**
Unmarks the selected object marked with the /mark (/m) command.

**/groupmark /gm**
Marks selected object for the entire group.

**/groupunmark /gum**
Unmarks the selected object for the entire group.

**/ignoregroupmarks <on|off>**
Ignores marks from others in your group.

**/automark <on|off> [radius in KM]**
Automatically marks all ships in KM radius.Bots are marked automatically in the\n  range specified whether on or off. If you want to completely disable automarking, set the radius to a number <= 0.