### PR TITLE
Fix `SetSizeToSmall` offsets and size

### DIFF
--- a/source/HkCbDeath.cpp
+++ b/source/HkCbDeath.cpp
@@ -7,9 +7,9 @@ std::wstring SetSizeToSmall(const std::wstring &wscDataFormat) {
     uint iFormat = wcstoul(wscDataFormat.c_str() + 2, nullptr, 16);
     wchar_t wszStyleSmall[32];
     wcscpy_s(wszStyleSmall, wscDataFormat.c_str());
-    swprintf_s(wszStyleSmall + std::size(wszStyleSmall) - 2, 2, L"%02X",
-               0x90 | (iFormat & 7));
-    return std::wstring(wszStyleSmall, std::size(wszStyleSmall));
+    swprintf_s(wszStyleSmall + std::size(wscDataFormat) - 2, 3, L"%02X",
+               0x90 | (iFormat & 7)); 
+    return std::wstring(wszStyleSmall, std::size(wscDataFormat));
 }
 
 /**************************************************************************************************************


### PR DESCRIPTION
As currently stands, the call to `swprintf_s` will never succeed because it requires enough room in the buffer for the null character at the end. Thus, asking for two hex characters requires 3 `wchar_t`'s worth of space. 

Furthermore, it currently sticks those at the end of the 32 character buffer rather than at the end of the `wscDataFormat` string.

This fix corrects a crash we have experienced on player deaths.