### PR TITLE
Allow `HK_GET_CLIENTID` to continue processing if the player is not online.

### DIFF
--- a/source/HkFuncPlayers.cpp
+++ b/source/HkFuncPlayers.cpp
@@ -47,7 +47,7 @@ HK_ERROR HkGetCash(const std::wstring &wscCharname, int &iCash) {
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 HK_ERROR HkAddCash(const std::wstring &wscCharname, int iAmount) {
-    HK_GET_CLIENTID(iClientID, wscCharname);
+    HK_GET_CLIENTID_OR_LOGGED_OUT(iClientID, wscCharname);
 
     uint iClientIDAcc = 0;
     if (iClientID == -1) {
@@ -160,7 +160,7 @@ HK_ERROR HkKickReason(const std::wstring &wscCharname,
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 HK_ERROR HkBan(const std::wstring &wscCharname, bool bBan) {
-    HK_GET_CLIENTID(iClientID, wscCharname);
+    HK_GET_CLIENTID_OR_LOGGED_OUT(iClientID, wscCharname);
 
     CAccount *acc;
     if (iClientID != -1)
@@ -456,7 +456,7 @@ HK_ERROR HkAddCargo(const std::wstring &wscCharname,
 
 HK_ERROR HkRename(const std::wstring &wscCharname,
                   const std::wstring &wscNewCharname, bool bOnlyDelete) {
-    HK_GET_CLIENTID(iClientID, wscCharname);
+    HK_GET_CLIENTID_OR_LOGGED_OUT(iClientID, wscCharname);
 
     if ((iClientID == -1) && !HkGetAccountByCharname(wscCharname))
         return HKE_CHAR_DOES_NOT_EXIST;

--- a/source/Hook.h
+++ b/source/Hook.h
@@ -920,5 +920,5 @@ extern EXPORT HK_ERROR HkGetClientID(bool &bIdString, uint &iClientID,
 #define HK_GET_CLIENTID(a, b)                                                  \
     bool bIdString = false;                                                    \
     uint a = uint(-1);                                                         \
-    if (auto err = HkGetClientID(bIdString, a, b); err != HKE_OK)              \
+    if (auto err = HkGetClientID(bIdString, a, b); err != HKE_OK && err != HKE_PLAYER_NOT_LOGGED_IN)              \
         return err;

--- a/source/Hook.h
+++ b/source/Hook.h
@@ -920,5 +920,11 @@ extern EXPORT HK_ERROR HkGetClientID(bool &bIdString, uint &iClientID,
 #define HK_GET_CLIENTID(a, b)                                                  \
     bool bIdString = false;                                                    \
     uint a = uint(-1);                                                         \
-    if (auto err = HkGetClientID(bIdString, a, b); err != HKE_OK && err != HKE_PLAYER_NOT_LOGGED_IN)              \
+    if (auto err = HkGetClientID(bIdString, a, b); err != HKE_OK)              \
+        return err;
+
+#define HK_GET_CLIENTID_OR_LOGGED_OUT(a,b)                                                           \
+    bool bIdString = false;                                                                          \
+    uint a = uint(-1);                                                                               \
+    if (auto err = HkGetClientID(bIdString, a, b); err != HKE_OK && err != HKE_PLAYER_NOT_LOGGED_IN) \
         return err;


### PR DESCRIPTION
`HK_GET_CLIENTID` would force the calling function to return early if the error was `HKE_PLAYER_NOT_LOGGED_IN`, which limits the usefulness of commands such as ban/unban. This change allows processing to continue with the first argument set to -1.