### PR TITLE
Core: Fix Trim Function

### DIFF
--- a/source/Tools.cpp
+++ b/source/Tools.cpp
@@ -441,7 +441,7 @@ template <typename Str> Str Trim(const Str &scIn) {
     auto start = scIn.find_first_not_of(trimmable);
     auto end = scIn.find_last_not_of(trimmable);
 
-    return scIn.substr(start, end - start);
+    return scIn.substr(start, end - start + 1);
 }
 
 std::wstring GetTimeString(bool bLocalTime) {


### PR DESCRIPTION
This function was cutting off the last character.

Fix discussed with FriendlyFire in #freelancer-programming on the discord on 03/10/2020 (bit late I know).