### PR TITLE
Core: Persist Groups when character is switched (optional)

### DIFF
--- a/misc/FLHook.ini
+++ b/misc/FLHook.ini
@@ -29,6 +29,7 @@ DisableNPCSpawns=0
 ReservedSlots=0
 TorpMissileBaseDamageMultiplier=1.0
 MaxGroupSize=8
+PersistGroup=no
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Plugins settings

--- a/source/HkCbIServerImpl.cpp
+++ b/source/HkCbIServerImpl.cpp
@@ -526,6 +526,10 @@ void __stdcall CharacterSelect(struct CHARACTER_ID const &cId,
                    (struct CHARACTER_ID const &cId, unsigned int iClientID),
                    (cId, iClientID));
 
+    // Get GroupID and store against client
+    if (set_bPersistGroup)
+        HkGetGroupID(iClientID, ClientInfo[iClientID].iGroupID);
+
     std::wstring wscCharBefore;
     try {
         const wchar_t *wszCharname =
@@ -536,6 +540,10 @@ void __stdcall CharacterSelect(struct CHARACTER_ID const &cId,
         ClientInfo[iClientID].iLastExitedBaseID = 0;
         ClientInfo[iClientID].iTradePartner = 0;
         Server.CharacterSelect(cId, iClientID);
+
+        // Add player back to group
+        if (set_bPersistGroup)
+            HkAddToGroup(iClientID, ClientInfo[iClientID].iGroupID);
     } catch (...) {
         HkAddKickLog(iClientID, L"Corrupt charfile?");
         HkKick(ARG_CLIENTID(iClientID));

--- a/source/HkFuncPlayers.cpp
+++ b/source/HkFuncPlayers.cpp
@@ -3,6 +3,33 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+HK_ERROR HkAddToGroup(uint iClientID, uint iGroupID) {
+    // check if logged in
+    if (iClientID == -1)
+        return HKE_PLAYER_NOT_LOGGED_IN;
+
+    uint iCurrentGroupID = Players.GetGroupID(iClientID);
+    if (iCurrentGroupID == iGroupID)
+        return HKE_INVALID_GROUP_ID;
+
+    CPlayerGroup *group = CPlayerGroup::FromGroupID(iGroupID);
+    if (!group)
+        return HKE_INVALID_GROUP_ID;
+    group->AddMember(iClientID);
+    return HKE_OK;
+}
+
+HK_ERROR HkGetGroupID(uint iClientID, uint &iGroupID) {
+    // check if logged in
+    if (iClientID == -1)
+        return HKE_PLAYER_NOT_LOGGED_IN;
+
+    iGroupID = Players.GetGroupID(iClientID);
+    return HKE_OK;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 HK_ERROR HkGetCash(const std::wstring &wscCharname, int &iCash) {
     HK_GET_CLIENTID(iClientID, wscCharname);
 

--- a/source/HkInit.cpp
+++ b/source/HkInit.cpp
@@ -194,7 +194,7 @@ void ClearClientInfo(uint iClientID) {
     ClientInfo[iClientID].bEngineKilled = false;
     ClientInfo[iClientID].bThrusterActivated = false;
     ClientInfo[iClientID].bTradelane = false;
-
+    ClientInfo[iClientID].iGroupID = 0;
     ClientInfo[iClientID].bSpawnProtected = false;
 
     CALL_PLUGINS_V(PLUGIN_ClearClientInfo, , (uint), (iClientID));

--- a/source/Hook.h
+++ b/source/Hook.h
@@ -328,6 +328,7 @@ enum HK_ERROR {
     HKE_PLUGIN_UNPAUSABLE,
     HKE_PLUGIN_NOT_FOUND,
     HKE_UNKNOWN_ERROR,
+    HKE_INVALID_GROUP_ID,
     HKE_CUSTOM_1,
     HKE_CUSTOM_2,
     HKE_CUSTOM_3,
@@ -492,6 +493,9 @@ struct CLIENT_INFO {
 
     // bans
     uint iConnects; // incremented when player connects
+
+    // Group
+    uint iGroupID;
 
     // other
     std::wstring wscHostname;
@@ -667,6 +671,8 @@ EXPORT void SendPrivateChat(uint iFromClientID, uint iToClientID,
 EXPORT void SendSystemChat(uint iFromClientID, const std::wstring &wscText);
 
 // HkFuncPlayers
+EXPORT HK_ERROR HkAddToGroup(uint iClientID, uint iGroupID);
+EXPORT HK_ERROR HkGetGroupID(uint iClientID, uint &iGroupID);
 EXPORT HK_ERROR HkGetCash(const std::wstring &wscCharname, int &iCash);
 EXPORT HK_ERROR HkAddCash(const std::wstring &wscCharname, int iAmount);
 EXPORT HK_ERROR HkKick(CAccount *acc);

--- a/source/Settings.cpp
+++ b/source/Settings.cpp
@@ -19,6 +19,7 @@ uint set_iReservedSlots;
 float set_fTorpMissileBaseDamageMultiplier;
 uint set_iMaxGroupSize;
 uint set_iDisableNPCSpawns;
+bool set_bPersistGroup;
 
 // log
 bool set_bDebug;
@@ -125,6 +126,7 @@ void LoadSettings() {
     set_fTorpMissileBaseDamageMultiplier = IniGetF(
         set_scCfgFile, "General", "TorpMissileBaseDamageMultiplier", 1.0f);
     set_iMaxGroupSize = IniGetI(set_scCfgFile, "General", "MaxGroupSize", 8);
+    set_bPersistGroup = IniGetB(set_scCfgFile, "General", "PersistGroup", false);
 
     // Log
     set_bDebug = IniGetB(set_scCfgFile, "Log", "Debug", false);

--- a/source/global.h
+++ b/source/global.h
@@ -170,6 +170,7 @@ extern EXPORT uint set_iReservedSlots;
 extern EXPORT uint set_iDisconnectDelay;
 extern EXPORT bool set_bAutoBuy;
 extern EXPORT float set_fTorpMissileBaseDamageMultiplier;
+extern EXPORT bool set_bPersistGroup;
 extern EXPORT bool set_MKM_bActivated;
 extern EXPORT std::wstring set_MKM_wscStyle;
 extern EXPORT std::list<MULTIKILLMESSAGE> set_MKM_lstMessages;


### PR DESCRIPTION
This new flag in FLHook.ini will make it so that players rejoin their player group when they switch characters. This is disabled by default.