### PR TITLE
Player Control: New option "EnableCargoDrop"

### DIFF
--- a/plugins/playercntl_plugin/src/Main.cpp
+++ b/plugins/playercntl_plugin/src/Main.cpp
@@ -38,6 +38,7 @@ bool set_bLocalTime = false;
 bool set_bEnableLoginSound = false;
 bool set_bEnableMe = false;
 bool set_bEnableDo = false;
+bool set_bEnableCargoDrop = false;
 
 float set_fSpinProtectMass;
 float set_fSpinImpulseMultiplier;
@@ -109,6 +110,7 @@ void LoadSettings() {
         IniGetB(scPluginCfgFile, "General", "EnableLoginSound", false);
     set_bEnableMe = IniGetB(scPluginCfgFile, "General", "EnableMe", false);
     set_bEnableDo = IniGetB(scPluginCfgFile, "General", "EnableDo", false);
+    set_bEnableCargoDrop = IniGetB(scPluginCfgFile, "General", "EnableCargoDrop", false);
 
     set_fSpinProtectMass =
         IniGetF(scPluginCfgFile, "General", "SpinProtectionMass", 180.0f);
@@ -126,11 +128,14 @@ void LoadSettings() {
     HyperJump::LoadSettings(scPluginCfgFile);
     PurchaseRestrictions::LoadSettings(scPluginCfgFile);
     IPBans::LoadSettings(scPluginCfgFile);
-    CargoDrop::LoadSettings(scPluginCfgFile);
     Restart::LoadSettings(scPluginCfgFile);
     RepFixer::LoadSettings(scPluginCfgFile);
     Message::LoadSettings(scPluginCfgFile);
     SystemSensor::LoadSettings(scPluginCfgFile);
+
+    if (set_bEnableCargoDrop)
+        CargoDrop::LoadSettings(scPluginCfgFile);
+
     CrashCatcher::Init();
 
     // Load sounds from config if enabled
@@ -156,12 +161,14 @@ void ClearClientInfo(uint iClientID) {
     returncode = DEFAULT_RETURNCODE;
     MiscCmds::ClearClientInfo(iClientID);
     HyperJump::ClearClientInfo(iClientID);
-    CargoDrop::ClearClientInfo(iClientID);
     IPBans::ClearClientInfo(iClientID);
     Message::ClearClientInfo(iClientID);
     PurchaseRestrictions::ClearClientInfo(iClientID);
     AntiJumpDisconnect::ClearClientInfo(iClientID);
     SystemSensor::ClearClientInfo(iClientID);
+
+    if (set_bEnableCargoDrop)
+        CargoDrop::ClearClientInfo(iClientID);
 }
 
 /** One second timer */
@@ -169,10 +176,12 @@ void HkTimer() {
     returncode = DEFAULT_RETURNCODE;
     MiscCmds::Timer();
     HyperJump::Timer();
-    CargoDrop::Timer();
     Message::Timer();
     Restart::Timer();
     Rename::Timer();
+
+    if (set_bEnableCargoDrop)
+        CargoDrop::Timer();
 }
 
 /// Hook for ship distruction. It's easier to hook this than the PlayerDeath
@@ -182,8 +191,11 @@ void SendDeathMsg(const std::wstring &wscMsg, uint iSystem,
     returncode = NOFUNCTIONCALL;
 
     HyperJump::SendDeathMsg(wscMsg, iSystem, iClientIDVictim, iClientIDKiller);
-    CargoDrop::SendDeathMsg(wscMsg, iSystem, iClientIDVictim, iClientIDKiller);
     Message::SendDeathMsg(wscMsg, iSystem, iClientIDVictim, iClientIDKiller);
+
+    if (set_bEnableCargoDrop)
+        CargoDrop::SendDeathMsg(wscMsg, iSystem, iClientIDVictim,
+                                iClientIDKiller);
 
     const wchar_t *victim =
         (const wchar_t *)Players.GetActiveCharacterName(iClientIDVictim);
@@ -594,7 +606,8 @@ void __stdcall StopTradelane(unsigned int iClientID, unsigned int p1,
 void __stdcall SPObjUpdate(struct SSPObjUpdateInfo const &ui,
                            unsigned int iClientID) {
     returncode = DEFAULT_RETURNCODE;
-    CargoDrop::SPObjUpdate(ui, iClientID);
+    if (set_bEnableCargoDrop)
+        CargoDrop::SPObjUpdate(ui, iClientID);
 }
 } // namespace HkIServerImpl
 


### PR DESCRIPTION
The CargoDrop feature of PlayerControl is not required by at least 2 servers that I am aware of. This should be an optional feature instead.