### PR TITLE
Player Control: Optional Restart Cost + Cash persists across restarts

### DIFF
--- a/plugins/playercntl_plugin/src/Main.cpp
+++ b/plugins/playercntl_plugin/src/Main.cpp
@@ -1,4 +1,4 @@
-﻿// Player Control plugin for FLHookPlugin
+// Player Control plugin for FLHookPlugin
 // Feb 2010 by Cannon
 //
 // This is free software; you can redistribute it and/or modify it as
@@ -40,6 +40,7 @@ bool set_bEnableMe = false;
 bool set_bEnableDo = false;
 bool set_bEnableCargoDrop = false;
 bool set_bEnableWardrobe = false;
+bool set_bEnableRestartCost = false;
 
 float set_fSpinProtectMass;
 float set_fSpinImpulseMultiplier;
@@ -105,6 +106,8 @@ void LoadSettings() {
         IniGetB(scPluginCfgFile, "General", "EnablePimpShip", false);
     set_bEnableRestart =
         IniGetB(scPluginCfgFile, "General", "EnableRestart", false);
+	set_bEnableRestartCost =
+        IniGetB(scPluginCfgFile, "General", "EnableRestartCost", false);
     set_bEnableGiveCash =
         IniGetB(scPluginCfgFile, "General", "EnableGiveCash", false);
     set_bEnableLoginSound =

--- a/plugins/playercntl_plugin/src/Main.h
+++ b/plugins/playercntl_plugin/src/Main.h
@@ -17,6 +17,7 @@ bool extern set_bEnableMoveChar;
 bool extern set_bEnableMe;
 bool extern set_bEnableDo;
 bool extern set_bEnableWardrobe;
+bool extern set_bEnableRestartCost;
 bool extern set_bLocalTime;
 
 // Imports from freelancer libraries.


### PR DESCRIPTION
Ability to charge credits for the restart templates. Also persisting cash across restarts as too many times noobs have wiped out their cash and asked for restores.