### PR TITLE
Fix for #31

### DIFF
--- a/plugins/playercntl_plugin/src/Givecash.cpp
+++ b/plugins/playercntl_plugin/src/Givecash.cpp
@@ -221,7 +221,7 @@ bool GiveCash::UserCmd_GiveCash(uint iClientID, const std::wstring &wscCmd,
 
     // Prevent target ship from becoming corrupt.
     float fTargetValue = 0.0f;
-    if (HKGetShipValue(wscTargetCharname, fTargetValue) != HKE_OK) {
+    if ((err = HKGetShipValue(wscTargetCharname, fTargetValue)) != HKE_OK) {
         PrintUserCmdText(iClientID, L"ERR " + HkErrGetText(err));
         return true;
     }

--- a/plugins/playercntl_plugin/src/Givecash.cpp
+++ b/plugins/playercntl_plugin/src/Givecash.cpp
@@ -260,8 +260,8 @@ bool GiveCash::UserCmd_GiveCash(uint iClientID, const std::wstring &wscCmd,
     }
 
     if (targetClientId != -1) {
-        if (ClientInfo[iClientID].iTradePartner ||
-            ClientInfo[targetClientId].iTradePartner) {
+        if (HkIsValidClientID(ClientInfo[iClientID].iTradePartner) ||
+            HkIsValidClientID(ClientInfo[targetClientId].iTradePartner)) {
             PrintUserCmdText(iClientID, L"ERR Trade window open");
             AddLog(
                 "NOTICE: Trade window open when sending %s credits from %s "
@@ -559,8 +559,8 @@ bool GiveCash::UserCmd_DrawCash(uint iClientID, const std::wstring &wscCmd,
 
     uint targetClientId = HkGetClientIdFromCharname(wscTargetCharname);
     if (targetClientId != -1) {
-        if (ClientInfo[iClientID].iTradePartner ||
-            ClientInfo[targetClientId].iTradePartner) {
+        if (HkIsValidClientID(ClientInfo[iClientID].iTradePartner) ||
+            HkIsValidClientID(ClientInfo[targetClientId].iTradePartner)) {
             PrintUserCmdText(iClientID, L"ERR Trade window open");
             AddLog(
                 "NOTICE: Trade window open when drawing %s credits from %s "

--- a/source/HkFuncPlayers.cpp
+++ b/source/HkFuncPlayers.cpp
@@ -31,7 +31,7 @@ HK_ERROR HkGetGroupID(uint iClientID, uint &iGroupID) {
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 HK_ERROR HkGetCash(const std::wstring &wscCharname, int &iCash) {
-    HK_GET_CLIENTID(iClientID, wscCharname);
+    HK_GET_CLIENTID_OR_LOGGED_OUT(iClientID, wscCharname);
 
     if ((iClientID != -1) && bIdString && HkIsInCharSelectMenu(iClientID))
         return HKE_NO_CHAR_SELECTED;
@@ -1044,7 +1044,7 @@ HK_ERROR HkGetGroupMembers(const std::wstring &wscCharname,
 HK_ERROR HkReadCharFile(const std::wstring &wscCharname,
                         std::list<std::wstring> &lstOutput) {
     lstOutput.clear();
-    HK_GET_CLIENTID(iClientID, wscCharname);
+    HK_GET_CLIENTID_OR_LOGGED_OUT(iClientID, wscCharname);
 
     std::wstring wscDir;
     CAccount *acc;

--- a/source/HkFuncTools.cpp
+++ b/source/HkFuncTools.cpp
@@ -228,7 +228,7 @@ HK_ERROR HkGetAccountDirName(CAccount *acc, std::wstring &wscDir) {
 
 HK_ERROR HkGetAccountDirName(const std::wstring &wscCharname,
                              std::wstring &wscDir) {
-    HK_GET_CLIENTID(iClientID, wscCharname);
+    HK_GET_CLIENTID_OR_LOGGED_OUT(iClientID, wscCharname);
     CAccount *acc;
     if (iClientID != -1)
         acc = Players.FindAccountFromClientID(iClientID);
@@ -250,7 +250,7 @@ HK_ERROR HkGetCharFileName(const std::wstring &wscCharname,
 
     char szBuf[1024] = "";
 
-    HK_GET_CLIENTID(iClientID, wscCharname);
+    HK_GET_CLIENTID_OR_LOGGED_OUT(iClientID, wscCharname);
     if (iClientID != -1) {
         GetFLName(szBuf,
                   (const wchar_t *)Players.GetActiveCharacterName(iClientID));

--- a/source/Tools.cpp
+++ b/source/Tools.cpp
@@ -429,6 +429,9 @@ BOOL FileExists(LPCTSTR szPath) {
 Remove leading and trailing spaces from the std::string  ~FlakCommon by Motah.
 */
 template <typename Str> Str Trim(const Str &scIn) {
+    if (scIn.empty())
+        return scIn;
+
     using Char = typename Str::value_type;
     constexpr auto trimmable = []() constexpr {
         if constexpr (std::is_same_v<Char, char>)


### PR DESCRIPTION
This was because the Trim function exceptioned when given an empty string. Check for empty string and just return it if there is nothing to be Trimmed.

Also a check to ensure that the Trade Partner is a valid client to not set off the anticheat for no reason.

Also replaced a few HK_GET_CLIENTID with HK_GET_CLIENTID_OR_LOGGED_OUT. This was causing functions to return early and not work meaning /drawcash and /givecash didn't work for offline characters.