### PR TITLE
Remove MissionMessageType enum redefinition

### DIFF
--- a/plugins/playercntl_plugin/src/PlayerInfo.cpp
+++ b/plugins/playercntl_plugin/src/PlayerInfo.cpp
@@ -18,13 +18,6 @@
 #include <plugin.h>
 #include <plugin_comms.h>
 
-enum MissionMessageType {
-    MissionMessageType_Failure, // mission failure
-    MissionMessageType_Type1,   // objective
-    MissionMessageType_Type2,   // objective
-    MissionMessageType_Type3,   // mission success
-};
-
 #define POPUPDIALOG_BUTTONS_LEFT_YES 1
 #define POPUPDIALOG_BUTTONS_CENTER_NO 2
 #define POPUPDIALOG_BUTTONS_RIGHT_LATER 4


### PR DESCRIPTION
PlayerControl currently fails compilation because this enum is being redefined. This was added to the SDK recently so there is no need for it to be here.